### PR TITLE
Lots of repeated code in class_example_group and define_example_group

### DIFF
--- a/lib/rspec-puppet/example.rb
+++ b/lib/rspec-puppet/example.rb
@@ -1,3 +1,4 @@
+require 'rspec-puppet/support'
 require 'rspec-puppet/example/define_example_group'
 require 'rspec-puppet/example/class_example_group'
 

--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -1,6 +1,7 @@
 module RSpec::Puppet
   module ClassExampleGroup
     include RSpec::Puppet::Matchers
+    include RSpec::Puppet::Support
 
     def subject
       @catalogue ||= catalogue
@@ -30,17 +31,7 @@ module RSpec::Puppet
       nodename = self.respond_to?(:node) ? node : Puppet[:certname]
       facts_val = self.respond_to?(:facts) ? facts : {}
 
-      node_obj = Puppet::Node.new(nodename)
-
-      node_obj.merge(facts_val)
-
-      # trying to be compatible with 2.7 as well as 2.6
-      if Puppet::Resource::Catalog.respond_to? :find
-        Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
-      else
-        require 'puppet/face'
-        Puppet::Face[:catalog, :current].find(node_obj.name, :use_node => node_obj)
-      end
+      build_catalog(nodename, facts_val)
     end
   end
 end

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -1,6 +1,7 @@
 module RSpec::Puppet
   module DefineExampleGroup
     include RSpec::Puppet::Matchers
+    include RSpec::Puppet::Support
 
     def subject
       @catalogue ||= catalogue
@@ -37,17 +38,7 @@ module RSpec::Puppet
       }
       facts_val.merge!(facts) if self.respond_to?(:facts)
 
-      node_obj = Puppet::Node.new(nodename)
-
-      node_obj.merge(facts_val)
-
-      # trying to be compatible with 2.7 as well as 2.6
-      if Puppet::Resource::Catalog.respond_to? :find
-        Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
-      else
-        require 'puppet/face'
-        Puppet::Face[:catalog, :current].find(node_obj.name, :use_node => node)
-      end
+      build_catalog(nodename, facts_val)
     end
   end
 end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -1,0 +1,17 @@
+module RSpec::Puppet
+  module Support 
+    def build_catalog nodename, facts_val
+      node_obj = Puppet::Node.new(nodename)
+
+      node_obj.merge(facts_val)
+
+      # trying to be compatible with 2.7 as well as 2.6
+      if Puppet::Resource::Catalog.respond_to? :find
+        Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
+      else
+        require 'puppet/face'
+        Puppet::Face[:catalog, :current].find(node_obj.name, :use_node => node_obj)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moved repeated code from both example_groups into a support module and build_catalog method in support.rb. Makes tweaking the catalog build section easier.
