### PR TITLE
Support for additional puppet settings

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -4,4 +4,7 @@ require 'rspec-puppet/example'
 
 RSpec.configure do |c|
   c.add_setting :module_path, :default => '/etc/puppet/modules'
+  c.add_setting :manifest_dir, :default => '/etc/puppet/manifests'
+  c.add_setting :manifest, :default => '/etc/puppet/manifests/site.pp'
+  c.add_setting :template_dir, :default => '/etc/puppet/templates'
 end

--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -9,6 +9,9 @@ module RSpec::Puppet
 
     def catalogue
       Puppet[:modulepath] = self.respond_to?(:module_path) ? module_path : RSpec.configuration.module_path
+      Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
+      Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest
+      Puppet[:templatedir] = self.respond_to?(:template_dir) ? template_dir : RSpec.configuration.template_dir
 
       klass_name = self.class.top_level_description.downcase
 
@@ -17,6 +20,8 @@ module RSpec::Puppet
       if File.exists?(File.join(Puppet[:modulepath], 'manifests', 'init.pp'))
         path_to_manifest = File.join([Puppet[:modulepath], 'manifests', klass_name.split('::')[1..-1]].flatten)
         import_str = "import '#{Puppet[:modulepath]}/manifests/init.pp'\nimport '#{path_to_manifest}.pp'\n"
+      elsif File.exists?(Puppet[:modulepath])
+        import_str = "import '#{Puppet[:manifest]}'\n"
       else
         import_str = ""
       end

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -11,12 +11,17 @@ module RSpec::Puppet
       define_name = self.class.top_level_description.downcase
 
       Puppet[:modulepath] = self.respond_to?(:module_path) ? module_path : RSpec.configuration.module_path
+      Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
+      Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest
+      Puppet[:templatedir] = self.respond_to?(:template_dir) ? template_dir : RSpec.configuration.template_dir
 
       # If we're testing a standalone module (i.e. one that's outside of a
       # puppet tree), the autoloader won't work, so we need to fudge it a bit.
       if File.exists?(File.join(Puppet[:modulepath], 'manifests', 'init.pp'))
         path_to_manifest = File.join([Puppet[:modulepath], 'manifests', define_name.split('::')[1..-1]].flatten)
         import_str = "import '#{Puppet[:modulepath]}/manifests/init.pp'\nimport '#{path_to_manifest}.pp'\n"
+      elsif File.exists?(Puppet[:modulepath])
+        import_str = "import '#{Puppet[:manifest]}'\n"
       else
         import_str = ""
       end


### PR DESCRIPTION
Hi Tim,
this is a simple commit that adds support for setting puppet's manifestdir, manifest and templatedir through rspec. All comments welcome.

Cheers,
Atha
