### PR TITLE
Fix rspec dependency

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -1,4 +1,5 @@
 require 'puppet'
+require 'rspec'
 require 'rspec-puppet/matchers'
 require 'rspec-puppet/example'
 


### PR DESCRIPTION
Without this patch, working with rspec-puppet in IRB fails when directly
requiring the library:

```
ruby-1.8.7-p334 :001 > require 'rspec-puppet'
NameError: uninitialized constant RSpec
    from /Users/jeff/.rvm/gems/ruby-1.8.7-p334@puppet/gems/rspec-puppet-0.1.0/lib/rspec-puppet/matchers/create_generic.rb:1
    from /Users/jeff/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
    from /Users/jeff/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
    from /Users/jeff/.rvm/gems/ruby-1.8.7-p334@puppet/gems/rspec-puppet-0.1.0/lib/rspec-puppet/matchers.rb:1
    from /Users/jeff/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
    from /Users/jeff/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
    from /Users/jeff/.rvm/gems/ruby-1.8.7-p334@puppet/gems/rspec-puppet-0.1.0/lib/rspec-puppet.rb:2
    from /Users/jeff/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:58:in `gem_original_require'
    from /Users/jeff/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:58:in `require'
    from (irb):1
```

This patch fixes the problem by requiring rspec directly from rspec-puppet.rb
