### PR TITLE
Add Regexp support to with_* matchers and improve error messages

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -30,11 +30,19 @@ module RSpec::Puppet
         if resource.nil?
           ret = false
         else
+          rsrc_hsh = resource.to_hash
           if @expected_params
             @expected_params.each do |name, value|
-              unless resource.send(:parameters)[name.to_sym].to_s == value.to_s
-                ret = false
-                (@errors ||= []) << "#{name.to_s} set to `#{value.inspect}`"
+              if value.kind_of?(Regexp) then
+                unless rsrc_hsh[name.to_sym].to_s =~ value
+                  ret = false
+                  (@errors ||= []) << "#{name.to_s} matching `#{value.inspect}` but its value of `#{rsrc_hsh[name.to_sym].inspect}` does not"
+                end
+              else
+                unless rsrc_hsh[name.to_sym].to_s == value.to_s
+                  ret = false
+                  (@errors ||= []) << "#{name.to_s} set to `#{value.inspect}` but it is set to `#{rsrc_hsh[name.to_sym].inspect}` in the catalogue"
+                end
               end
             end
           end
@@ -71,7 +79,7 @@ module RSpec::Puppet
       end
 
       def errors
-        @errors.nil? ? "" : " with #{@errors.join(', ')}"
+        @errors.nil? ? "" : " with #{@errors.join(', and parameter ')}"
       end
     end
 

--- a/spec/classes/boolean_regexp_spec.rb
+++ b/spec/classes/boolean_regexp_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'boolean' do
+  let(:title) { 'bool.testing' }
+  let(:params) { { :bool => false } }
+  let(:message_re) { /bool is false/ }
+
+  it { should create_notify("bool testing").with_message(message_re) }
+  it { should_not create_notify("bool testing").with_message(/true/) }
+end


### PR DESCRIPTION
Without this patch it is difficult to match portions of long strings
which are attribute values of resource parameters.  For example, the
content parameter of a file resource with a multi-line template.

This patch makes it easier to match portions of the parameter's value by
passing a Regexp instance to the with_ catch all matcher.

The use case looks like:

```
describe 'with lsbmajdistrelease available' do
  let(:facts) { @facter_facts.merge({'lsbmajdistrelease' => '6'}) }
  it { should_not contain_file('puppetenterprise.repo').with_content(missing_content) }
  it { should contain_package 'pe-ruby-devel' }
  it do
    should contain_file('puppetenterprise.repo').with_content(/baseurl=http/)
    should contain_file('puppetenterprise.repo').with_content(/pe_base/)
    should contain_file('puppetenterprise.repo').with_content(/pe_updates/)
    should contain_file('puppetenterprise.repo').with_content(/pe_extras/)
  end
end
```

This feature allows the same parameter to be matched multiple times using
multiple different regular expressions.

This patch also improves the error message by presenting the actual value in
the catalog when it does not match the expectation.  This change applies to
both String and Regexp expectation matches.

The error output now looks like:

```
1) pe_devel on redhat el6 os families with lsbmajdistrelease available
   Failure/Error: should contain_file('puppetenterprise.repo').with_content(/JEFF MCCUNE/)
     expected that the catalogue would contain File[puppetenterprise.repo] with content \
     matching `/JEFF MCCUNE/` but its value of `"# KERMIT FROG\n"` does not
```

Spec tests have been added to exercise the handling of Regexp instances.
