### PR TITLE
Cache the result of build_catalog

### DIFF
--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -34,12 +34,12 @@ module RSpec::Puppet
       end
 
       if !self.respond_to?(:params) || params == {}
-        Puppet[:code] = import_str + "include #{klass_name}"
+        code = import_str + "include #{klass_name}"
       else
-        Puppet[:code] = import_str + 'class' + " { \"" + klass_name + "\": " + params.keys.map { |r| "#{r.to_s} => #{params[r].inspect}"
+        code = import_str + 'class' + " { \"" + klass_name + "\": " + params.keys.map { |r| "#{r.to_s} => #{params[r].inspect}"
       }.join(',' ) + " }"
       end
-      Puppet[:code] = pre_cond + "\n" + Puppet[:code]
+      code = pre_cond + "\n" + code
 
       nodename = self.respond_to?(:node) ? node : Puppet[:certname]
       facts_val = {
@@ -49,7 +49,7 @@ module RSpec::Puppet
       }
       facts_val.merge!(munge_facts(facts)) if self.respond_to?(:facts)
 
-      build_catalog(nodename, facts_val)
+      build_catalog(nodename, facts_val, code)
     end
   end
 end

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -41,7 +41,7 @@ module RSpec::Puppet
         pre_cond = ""
       end
 
-      Puppet[:code] = pre_cond + "\n" + import_str + define_name + " { \"" + title + "\": " + param_str + " }"
+      code = pre_cond + "\n" + import_str + define_name + " { \"" + title + "\": " + param_str + " }"
 
       nodename = self.respond_to?(:node) ? node : Puppet[:certname]
       facts_val = {
@@ -51,7 +51,7 @@ module RSpec::Puppet
       }
       facts_val.merge!(munge_facts(facts)) if self.respond_to?(:facts)
 
-      build_catalog(nodename, facts_val)
+      build_catalog(nodename, facts_val, code)
     end
   end
 end

--- a/lib/rspec-puppet/example/host_example_group.rb
+++ b/lib/rspec-puppet/example/host_example_group.rb
@@ -13,7 +13,7 @@ module RSpec::Puppet
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest
       Puppet[:templatedir] = self.respond_to?(:template_dir) ? template_dir : RSpec.configuration.template_dir
       Puppet[:config] = self.respond_to?(:config) ? config : RSpec.configuration.config
-      Puppet[:code] = ""
+      code = ""
 
       nodename = self.class.top_level_description.downcase
 
@@ -24,7 +24,7 @@ module RSpec::Puppet
       }
       facts_val.merge!(munge_facts(facts)) if self.respond_to?(:facts)
 
-      build_catalog(nodename, facts_val)
+      build_catalog(nodename, facts_val, code)
     end
   end
 end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -4,7 +4,9 @@ module RSpec::Puppet
     @@cache = {}
 
     protected
-    def build_catalog_without_cache nodename, facts_val
+    def build_catalog_without_cache(nodename, facts_val, code)
+      Puppet[:code] = code
+
       node_obj = Puppet::Node.new(nodename)
 
       node_obj.merge(facts_val)


### PR DESCRIPTION
Use simple memoization pattern to cache RSpec::Puppet::Support::build_catalog results.

This change speeds up our hosts specs quite a bit.
