### PR TITLE
Explicitly load functions for scope instance

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -28,6 +28,8 @@ module RSpec::Puppet
 
       scope = Puppet::Parser::Scope.new(:compiler => @compiler)
 
+      Puppet::Parser::Functions.function(function_name)
+
       scope.method "function_#{function_name}".to_sym
     end
 


### PR DESCRIPTION
Functions are loaded in Puppet as they are encountered.

If a user is just invoking functions from Ruby, then they
need to manually call the Puppet::Parser::Functions.function method
to ensure that functions are properly loaded.

This commit adds the load function call to ensure that the functions being
tested can be found by puppet.
