### PR TITLE
Add Puppet[:libdir] as an rspec config option

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -9,5 +9,6 @@ RSpec.configure do |c|
   c.add_setting :manifest_dir, :default => nil
   c.add_setting :manifest, :default => nil
   c.add_setting :template_dir, :default => nil
+  c.add_setting :lib_dir, :default => nil
   c.add_setting :config, :default => nil
 end

--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -12,6 +12,7 @@ module RSpec::Puppet
       Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest
       Puppet[:templatedir] = self.respond_to?(:template_dir) ? template_dir : RSpec.configuration.template_dir
+      Puppet[:libdir] = self.respond_to?(:lib_dir) ? lib_dir : RSpec.configuration.lib_dir
       Puppet[:config] = self.respond_to?(:config) ? config : RSpec.configuration.config
 
       klass_name = self.class.top_level_description.downcase

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -14,6 +14,7 @@ module RSpec::Puppet
       Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest
       Puppet[:templatedir] = self.respond_to?(:template_dir) ? template_dir : RSpec.configuration.template_dir
+      Puppet[:libdir] = self.respond_to?(:lib_dir) ? lib_dir : RSpec.configuration.lib_dir
       Puppet[:config] = self.respond_to?(:config) ? config : RSpec.configuration.config
 
       # If we're testing a standalone module (i.e. one that's outside of a

--- a/lib/rspec-puppet/example/host_example_group.rb
+++ b/lib/rspec-puppet/example/host_example_group.rb
@@ -12,6 +12,7 @@ module RSpec::Puppet
       Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest
       Puppet[:templatedir] = self.respond_to?(:template_dir) ? template_dir : RSpec.configuration.template_dir
+      Puppet[:libdir] = self.respond_to?(:lib_dir) ? lib_dir : RSpec.configuration.lib_dir
       Puppet[:config] = self.respond_to?(:config) ? config : RSpec.configuration.config
       code = ""
 


### PR DESCRIPTION
Unsure if this is the correct solution to the problem, so I'd appreciate feedback if not.

My example setup:

```
$ tree
.
|-- manifests
|   `-- init.pp
|-- Rakefile
`-- spec
    |-- classes
    |   `-- ssh_spec.rb
    |-- defines
    |-- fixtures
    |   |-- manifests
    |   |   `-- site.pp
    |   `-- modules
    |       |-- augeasproviders -> /home/dcleal/code/augeas/domcleal-augeasproviders
    |       `-- ssh
    |           `-- manifests -> ../../../../manifests
    |-- functions
    |-- hosts
    `-- spec_helper.rb

12 directories, 5 files
```

The augeasproviders module is from domcleal/augeasproviders and distributes bits of its own under its "lib" directory:

```
lib
|-- augeasproviders
|   `-- provider.rb
|-- augeasproviders.rb
`-- puppet
    |-- provider
    |   |-- sshd_config
    |   |   `-- augeas.rb
```

The provider then has a `require 'augeasproviders/provider'`, which fails.  I believe this pattern is essentially what was [agreed on puppet-users recently](https://groups.google.com/d/topic/puppet-users/BGTVWDxr1vc/discussion) (albeit with "PuppetX").

```
Could not autoload sshd_config: Could not autoload /home/dcleal/code/puppet/augeas-examples/modules/ssh/spec/fixtures/modules/augeasproviders/lib/puppet/provider/sshd_config/augeas.rb: cannot load such file -- augeasproviders/provider at /home/dcleal/code/puppet/augeas-examples/modules/ssh/spec/fixtures/modules/ssh/manifests/init.pp:7 on node iridium
```

So this this allows lib_dir to be set.  I set up my "ssh" module's spec_helper.rb with this:

```
c.lib_dir = Dir["#{c.module_path}/*/lib"].entries.join(File::PATH_SEPARATOR)
```
