### PR TITLE
Add contain_all_deps matcher

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -37,23 +37,13 @@ module RSpec::Puppet
 
       def matches?(catalogue)
         ret = true
-        if @title.class.to_s == 'Regexp' then
-          resource = catalogue.resources.select { |r|
-	    r.type == @referenced_type
-          }.select { |r|
-            @title.match(r.title) != nil
-          }
-        else
-          resource = catalogue.resource(@referenced_type, @title)
-        end
+        resource = catalogue.resource(@referenced_type, @title)
 
         if resource.nil?
           ret = false
         else
-          if @expected_params || @unexpected_params then
-            rsrc_hsh = resource.to_hash
-          end
-          if @expected_params then
+          rsrc_hsh = resource.to_hash
+          if @expected_params
             @expected_params.each do |name, value|
               if value.kind_of?(Regexp) then
                 unless rsrc_hsh[name.to_sym].to_s =~ value

--- a/lib/rspec-puppet/matchers/create_resource.rb
+++ b/lib/rspec-puppet/matchers/create_resource.rb
@@ -8,11 +8,7 @@ module RSpec::Puppet
         resources = catalogue.resources.select { |r|
           r.type == referenced_type(expected_type)
         }.select { |r|
-          if expected_title.class.to_s == 'Regexp' then
-            (expected_title.match(r.title) != nil) if r.respond_to? :title
-          else
-            r.title == expected_title if r.respond_to? :title
-          end
+          r.title == expected_title if r.respond_to? :title
         }
 
         unless resources.length == 1
@@ -45,20 +41,12 @@ module RSpec::Puppet
 
       description do
         type = referenced_type(expected_type)
-        if expected_title.class.to_s == 'Regexp' then
-          "create #{type} matching a Regexp"
-        else
-          "create #{type}['#{expected_title}']"
-        end
+        "create #{type}['#{expected_title}']"
       end
 
       failure_message_for_should do |actual|
         type = referenced_type(expected_type)
-        if expect_title.class.to_s == 'Regexp' then
-          "expected that the catalogue would contain #{type}[matching Regexp]#{errors}"
-        else
-          "expected that the catalogue would contain #{type}['#{expected_title}']#{errors}"
-        end
+        "expected that the catalogue would contain #{type}['#{expected_title}']#{errors}"
       end
     end
   end


### PR DESCRIPTION
This matcher add support to check that no expressed dependencies are left with undefined referenced resources. Only dependencies expressed inside resources (require, before, subscribe, notify) are checked, not ordering/notification arrows (->/~>). The latter might be added in the future.
