### PR TITLE
Fix puppet 3 issue with multiple classes and functions by moving re-initing puppet each catalog compile

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -6,10 +6,6 @@ require 'rspec-puppet/matchers'
 require 'rspec-puppet/example'
 require 'rspec-puppet/setup'
 
-if Integer(Puppet.version.split('.').first) >= 3
-  Puppet.initialize_settings
-end
-
 RSpec.configure do |c|
   c.add_setting :module_path, :default => '/etc/puppet/modules'
   c.add_setting :manifest_dir, :default => nil

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -5,6 +5,10 @@ module RSpec::Puppet
 
     protected
     def build_catalog_without_cache(nodename, facts_val, code)
+      if Integer(Puppet.version.split('.').first) >= 3
+          Puppet.initialize_settings
+      end
+
       Puppet[:code] = code
 
       node_obj = Puppet::Node.new(nodename)


### PR DESCRIPTION
This fixes the issue described in #60 and #58 for me.  It passes tests on puppet 3 also.

I'm positive there is a better way to re-initialize the puppet engine, however, I tried calling various clear methods before settling on this with no positive results.
