### PR TITLE
Allow to pass procs to with_ / without_

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -55,6 +55,13 @@ module RSpec::Puppet
                   ret = false
                   (@errors ||= []) << "#{name.to_s} set to `#{value.inspect}` but it is set to `#{rsrc_hsh[name.to_sym].inspect}` in the catalogue"
                 end
+              elsif value.kind_of?(Proc) then
+                ret = value.call(rsrc_hsh[name.to_sym].to_s)
+                if ret != true
+                  ret = false
+                  (@errors ||= []) << "#{name.to_s} `#{rsrc_hsh[name.to_sym].inspect}` passed to`#{value.to_s}` would be
+`true` but it's `#{ret}`"
+                end
               else
                 unless rsrc_hsh[name.to_sym].to_s == value.to_s
                   ret = false

--- a/spec/defines/sysctl_spec.rb
+++ b/spec/defines/sysctl_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+nodoublequotes = Proc.new do |x|
+  not x =~ /"/
+end
+
 describe 'sysctl' do
   let(:title) { 'vm.swappiness' }
   let(:params) { {:value => '60'} }
@@ -8,6 +12,7 @@ describe 'sysctl' do
   it { should create_augeas('sysctl/vm.swappiness') \
     .with_context('/files/etc/sysctl.conf') \
     .with_changes("set vm.swappiness '60'") \
+    .with_changes(nodoublequotes) \
     .with_onlyif("match vm.swappiness[.='60'] size == 0") \
     .with_notify('Exec[sysctl/reload]')\
     .without_foo }


### PR DESCRIPTION
This allows for more complex checks on the resources content. E.g.  to
make sure the generated content doesn't contain string representations
of 'undef' or 'nil' or validates correctly against an XML schema.
