### PR TITLE
Documenting the only_with matchers (PR 80) for rspec-puppet.com

### DIFF
--- a/matchers/index.md
+++ b/matchers/index.md
@@ -39,6 +39,15 @@ it { should contain_service('mysql-server').with_ensure('present') }
 it { should contain_file('/etc/logrotate.d/apache').with_content(/compress/) }
 {% endhighlight %}
 
+#### only_with_\*
+If you want to test the presence of an exact set of parameters on your
+resources, you can do so by chaining the `.only_with_<parameter>` methods.
+These methods also take an exact value or a regular expression.
+
+{% highlight ruby %}
+it { should contain_service('httpd').only_with_ensure('running') }
+{% endhighlight %}
+
 #### with and without
 This can become very verbose when you're testing for multiple parameters, so
 you can also chain `.with` and `.without` methods on to the end of your tests
@@ -50,6 +59,20 @@ it do
     'ensure'     => 'running',
     'enable'     => 'true',
     'hasrestart' => 'true',
+  )
+end
+{% endhighlight %}
+
+#### only_with
+The chaining also works with the `.only_with` method, by passing a hash of
+parameters. These will be the exact set of parameters the catalogue should
+contain for that resource or class.
+
+{% highlight ruby %}
+it do
+  should contain_user('luke').only_with(
+    'ensure' => 'present',
+    'uid'    => '501',
   )
 end
 {% endhighlight %}


### PR DESCRIPTION
This contains some documentation for the extra matchers added by pull request [80](https://github.com/rodjek/rspec-puppet/pull/80). The code has been merged already.
