### PR TITLE
Add facter gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>=
 rspecversion = ENV.key?('RSPEC_VERSION') ? "= #{ENV['RSPEC_VERSION']}" : ['>= 2.9']
 
 gem 'rake'
+gem 'facter'
 gem 'rspec', rspecversion
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper'


### PR DESCRIPTION
Otherwise we fail with

$ bundle exec rake test
/usr/bin/ruby1.9.1 -S rspec ./spec/classes/boolean_regexp_spec.rb ./spec/classes/boolean_spec.rb ./spec/classes/cycle_bad_spec.rb ./spec/classes/cycle_good_spec.rb ./spec/classes/escape_spec.rb ./spec/classes/sysctl_common_spec.rb ./spec/defines/arrayparams_spec.rb ./spec/defines/escape_def_spec.rb ./spec/defines/sysctl_before_spec.rb ./spec/defines/sysctl_spec.rb ./spec/functions/split_spec.rb ./spec/hosts/bad_dep_host_spec.rb ./spec/hosts/foo_spec.rb ./spec/hosts/good_dep_host_spec.rb ./spec/hosts/testhost_spec.rb
/var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/puppet-3.0.1/lib/puppet.rb:4:in `require': cannot load such file -- facter (LoadError)
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/puppet-3.0.1/lib/puppet.rb:4:in`<top (required)>'
    from /var/scratch/debian/puppet/rspec-puppet/lib/rspec-puppet.rb:1:in `require'
    from /var/scratch/debian/puppet/rspec-puppet/lib/rspec-puppet.rb:1:in`<top (required)>'
    from /var/scratch/debian/puppet/rspec-puppet/spec/spec_helper.rb:1:in `require'
    from /var/scratch/debian/puppet/rspec-puppet/spec/spec_helper.rb:1:in`<top (required)>'
    from /var/scratch/debian/puppet/rspec-puppet/spec/classes/boolean_regexp_spec.rb:1:in `require'
    from /var/scratch/debian/puppet/rspec-puppet/spec/classes/boolean_regexp_spec.rb:1:in`<top (required)>'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/configuration.rb:784:in `load'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/configuration.rb:784:in`block in load_spec_files'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/configuration.rb:784:in `each'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/configuration.rb:784:in`load_spec_files'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/command_line.rb:22:in `run'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/runner.rb:69:in`run'
    from /var/scratch/debian/puppet/rspec-puppet/vendor/ruby/1.9.1/gems/rspec-core-2.12.0/lib/rspec/core/runner.rb:8:in `block in autorun'
