### PR TITLE
Allow to set up hiera test fixtures

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -13,4 +13,5 @@ RSpec.configure do |c|
   c.add_setting :template_dir, :default => nil
   c.add_setting :config, :default => nil
   c.add_setting :confdir, :default => '/etc/puppet'
+  c.add_setting :hiera_config, :default => nil
 end

--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -10,7 +10,7 @@ module RSpec::Puppet
     def catalogue
       vardir = Dir.mktmpdir
       Puppet[:vardir] = vardir
-      Puppet[:hiera_config] = File.join(vardir, "hiera.yaml") if Puppet[:hiera_config] == File.expand_path("/dev/null")
+      Puppet[:hiera_config] = self.respond_to?(:hiera_config) ? hiera_config : RSpec.configuration.hiera_config
       Puppet[:modulepath] = self.respond_to?(:module_path) ? module_path : RSpec.configuration.module_path
       Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -12,7 +12,7 @@ module RSpec::Puppet
 
       vardir = Dir.mktmpdir
       Puppet[:vardir] = vardir
-      Puppet[:hiera_config] = File.join(vardir, "hiera.yaml") if Puppet[:hiera_config] == File.expand_path("/dev/null")
+      Puppet[:hiera_config] = self.respond_to?(:hiera_config) ? hiera_config : RSpec.configuration.hiera_config
       Puppet[:modulepath] = self.respond_to?(:module_path) ? module_path : RSpec.configuration.module_path
       Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest

--- a/lib/rspec-puppet/example/host_example_group.rb
+++ b/lib/rspec-puppet/example/host_example_group.rb
@@ -10,7 +10,7 @@ module RSpec::Puppet
     def catalogue
       vardir = Dir.mktmpdir
       Puppet[:vardir] = vardir
-      Puppet[:hiera_config] = File.join(vardir, "hiera.yaml") if Puppet[:hiera_config] == File.expand_path("/dev/null")
+      Puppet[:hiera_config] = self.respond_to?(:hiera_config) ? hiera_config : RSpec.configuration.hiera_config
       Puppet[:modulepath] = self.respond_to?(:module_path) ? module_path : RSpec.configuration.module_path
       Puppet[:manifestdir] = self.respond_to?(:manifest_dir) ? manifest_dir : RSpec.configuration.manifest_dir
       Puppet[:manifest] = self.respond_to?(:manifest) ? manifest : RSpec.configuration.manifest


### PR DESCRIPTION
Currently puppet reads hiera settings from a randomly created vardir or
from puppet config. For proper test fixtrues allow it to be set either
via RSpec.configuration or via :hiera_config in specific examples e.g.:

spec/fixtures/hiera/hiera.yaml:

``` yaml
  ---
  :backends:
    - yaml
  :hierarchy:
    - test

   :yaml:
      :datadir: 'spec/fixtures/hiera'
```

spec/fixtures/hiera/test.yaml:

``` yaml
  foovar: 'bar'
```

spec/spec_helper.rb:

``` ruby
  RSpec.configure do |c|
    ...
    c.hiera_config = File.join(fixture_path, 'hiera/hiera.yaml')
    ...
  end
```

This make testing modules with hiera lookups very simple.
