### PR TITLE
Missing import in "function_example_group.rb"

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -4,6 +4,7 @@ module RSpec::Puppet
   module FunctionExampleGroup
     include RSpec::Puppet::FunctionMatchers
     include RSpec::Puppet::ManifestMatchers
+    include RSpec::Puppet::Support
     PuppetInternals = PuppetlabsSpec::PuppetInternals
 
     def subject


### PR DESCRIPTION
When mocking facts when testing functions like:

``` ruby
let(:facts) { {:ipaddress => '207.130.146.129'} }
```

we get the following error when running rake:

```
NoMethodError:
       undefined method `munge_facts' for #<RSpec::Core::ExampleGroup::Nested_2:0x7fc0934de058>
```

The following must be included in ''function_example_group.rb":

```
include RSpec::Puppet::Support
```
