### PR TITLE
Perform order insensitive matches on hashes

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -145,6 +145,8 @@ module RSpec::Puppet
             check_array_param(type, resource, param, value)
           elsif value.is_a? Proc
             check_proc_param(type, resource, param, value)
+          elsif value.is_a? Hash
+            check_hash_param(type, resource, param, value)
           else
             check_string_param(type, resource, param, value)
           end
@@ -169,6 +171,13 @@ module RSpec::Puppet
         actual_return = value.call(resource[param].to_s)
         if actual_return != expected_return
           @errors << ProcMatchError.new(param, expected_return, actual_return, type == :not)
+        end
+      end
+
+      def check_hash_param(type, resource, param, value)
+        op = type == :not ? :"!=" : :"=="
+        unless resource[param].send(op, value)
+          @errors << MatchError.new(param, value, resource[param], type == :not)
         end
       end
 

--- a/spec/classes/hash_spec.rb
+++ b/spec/classes/hash_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'hash' do
+  let(:title) { 'huh?' }
+  let(:params) do
+    {
+      'data'  => {
+        'baz' => 'quux',
+        'foo' => 'bar',
+      }
+    }
+  end
+
+  it {
+    should contain_hash__def('thing').with({
+      'data'  => {
+        'foo' => 'bar',
+        'baz' => 'quux',
+      }
+    })
+  }
+
+  it {
+    should contain_hash__def('thing').with({
+      'data'  => {
+        'baz' => 'quux',
+        'foo' => 'bar',
+      }
+    })
+  }
+end

--- a/spec/fixtures/modules/hash/manifests/def.pp
+++ b/spec/fixtures/modules/hash/manifests/def.pp
@@ -1,0 +1,5 @@
+define hash::def($data = {}) {
+  $template = inline_template('<%= data.flatten.join(",") %>')
+
+  notify { "$template": }
+}

--- a/spec/fixtures/modules/hash/manifests/init.pp
+++ b/spec/fixtures/modules/hash/manifests/init.pp
@@ -1,0 +1,5 @@
+class hash($data) {
+  hash::def { "thing":
+    data    => $data,
+  }
+}


### PR DESCRIPTION
The current behavior of rspec-puppet is to cast anything that isn't an
Array, Regexp, or Proc into a string and do a string compare to
determine equality. In the case of hashes this stringification is order
dependent, and can have different ordering on different platforms, this
making previously valid tests fail.

This commit resolves this behavior by doing a normal hash comparison,
which ensures that both hashes have the same size and each key/value
pair match.
