### PR TITLE
Recursively validate puppet parameter values

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -1,0 +1,110 @@
+module RSpec::Puppet
+  module ManifestMatchers
+    class ParameterMatcher
+      include RSpec::Puppet::Errors
+
+      # @param parameter [Symbol] The specific parameter to check
+      # @param value [Object] The expected data to match the parameter against
+      # @param type [:should, :not] Whether the given parameter should match
+      def initialize(parameter, value, type)
+        @parameter, @value, @type = parameter, value, type
+
+        @should_match = (type == :should)
+
+        @errors = []
+      end
+
+      # Ensure that the actual parameter matches the expected parameter.
+      #
+      # @param resource [Hash<Symbol, Object>] A hash representing a Puppet
+      #   resource in the catalog
+      #
+      # @return [true, false]
+      def matches?(resource)
+
+        @resource = resource
+
+        actual   = @resource[@parameter]
+        expected = @value
+
+        retval = check(expected, actual)
+
+        unless retval
+          @errors << MatchError.new(@parameter, expected, actual, !@should_match)
+        end
+
+        retval
+      end
+
+      # @!attribute [r] errors
+      #   @return [Array<Object < StandardError>] All expectation errors
+      #     generated on this parameter.
+      attr_reader :errors
+
+      private
+
+      # Recursively check that the `expected` and `actual` data structures match
+      #
+      # @param expected [Object] The expected value of the given resource param
+      # @param actual [Object] The value of the resource as found in the catalogue
+      #
+      # @return [true, false] If the resource matched
+      def check(expected, actual)
+        case expected
+        when Proc
+          check_proc(expected, actual)
+        when Regexp
+          check_regexp(expected, actual)
+        when Hash
+          check_hash(expected, actual)
+        when Array
+          check_array(expected, actual)
+        else
+          check_string(expected, actual)
+        end
+      end
+
+      def check_proc(expected, actual)
+        expected_return = @should_match
+        actual_return   = expected.call(actual)
+
+        actual_return == expected_return
+      end
+
+      def check_regexp(expected, actual)
+        !!(actual.to_s.match expected) == @should_match
+      end
+
+      # Ensure that two hashes have the same number of keys, and that for each
+      # key in the expected hash, there's a stringified key in the actual hash
+      # with a matching value.
+      def check_hash(expected, actual)
+        op = @should_match ? :"==" : :"!="
+
+        unless expected.keys.size.send(op, actual.keys.size)
+          return false
+        end
+
+        expected.keys.all? do |key|
+          check(expected[key], actual[key.to_s])
+        end
+      end
+
+      def check_array(expected, actual)
+        op = @should_match ? :"==" : :"!="
+
+        unless expected.size.send(op, actual.size)
+          return false
+        end
+
+        (0...expected.size).all? do |index|
+          check(expected[index], actual[index])
+        end
+      end
+
+      def check_string(expected, actual)
+        (expected.to_s == actual.to_s) == @should_match
+      end
+    end
+  end
+end

--- a/spec/classes/array_spec.rb
+++ b/spec/classes/array_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe 'structured_data' do
+  describe "with a single level array of strings" do
+    let(:params) do
+      {'data'  => ['foo', 'bar', 'baz', 'quux']}
+    end
+
+    it {
+      should contain_structured_data__def('thing').with(
+        { 'data'  => ['foo', 'bar', 'baz', 'quux'] }
+      )
+    }
+  end
+
+  describe "with integers as data values" do
+    let(:params) do
+      { 'data'  => ['first', 1, 'second', 2] }
+    end
+
+    it {
+      should contain_structured_data__def('thing').with(
+        { 'data' => ['first', 1, 'second', 2] }
+      )
+    }
+  end
+
+  describe 'with nested arrays' do
+    let(:params) do
+      { 'data'  => [
+          'first',
+          'second',
+          ['third', 'fourth'],
+          5,
+          6
+        ]
+      }
+    end
+
+    # Puppet 2.6 will automatically flatten nested arrays. If we're going
+    # to be testing recursive data structures, we might as well ensure that
+    # we're still handling numeric values correctly.
+    describe 'on Puppet 2.6', :if => Puppet.version =~ /^2\.6/ do
+      it {
+        should contain_structured_data__def('thing').with(
+          { 'data'  => [
+              'first',
+              'second',
+              'third',
+              'fourth',
+              5,
+              6
+            ]
+          }
+        )
+      }
+    end
+
+    describe 'on Puppet 2.7 and later', :unless => Puppet.version =~ /^2\.6/ do
+      it {
+        should contain_structured_data__def('thing').with(
+          { 'data'  => [
+              'first',
+              'second',
+              ['third', 'fourth'],
+              5,
+              6
+            ]
+          }
+        )
+      }
+    end
+  end
+end

--- a/spec/classes/hash_spec.rb
+++ b/spec/classes/hash_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'structured_data' do
+  describe "with a single level hash of strings" do
+    let(:params) do
+      {'data'  => {'foo' => 'bar', 'baz' => 'quux'}}
+    end
+
+    it {
+      should contain_structured_data__def('thing').with(
+        {'data'  => {'foo' => 'bar', 'baz' => 'quux'}}
+      )
+    }
+  end
+
+  describe "with integers as keys" do
+    let(:params) do
+      { 'data'  => {1 => 'uno', 2 => 'dos'}}
+    end
+
+    it {
+      should contain_structured_data__def('thing').with(
+        { 'data'  => {1 => 'uno', 2 => 'dos'}}
+      )
+    }
+  end
+
+  describe 'with integers as values' do
+    let(:params) do
+      { 'data'  => {'first' => 1, 'second' => 2}}
+    end
+
+    it {
+      should contain_structured_data__def('thing').with(
+        { 'data'  => {'first' => 1, 'second' => 2}}
+      )
+    }
+  end
+
+  describe 'with nested hashes' do
+    let(:params) do
+      { 'data'  => {
+          'first'  => 1,
+          'second' => 2,
+          'third'  => {
+            'alpha' => 'a',
+            'beta'  => 'b',
+          }
+        }
+      }
+    end
+
+    it {
+      should contain_structured_data__def('thing').with(
+        { 'data'  => {
+            'first'  => 1,
+            'second' => 2,
+            'third'  => {
+              'alpha' => 'a',
+              'beta'  => 'b',
+            }
+          }
+        }
+      )
+    }
+  end
+end
+

--- a/spec/fixtures/modules/structured_data/manifests/def.pp
+++ b/spec/fixtures/modules/structured_data/manifests/def.pp
@@ -1,0 +1,5 @@
+define structured_data::def($data = {}) {
+  $template = inline_template('<%= data.inspect %>')
+
+  notify { "$template": }
+}

--- a/spec/fixtures/modules/structured_data/manifests/init.pp
+++ b/spec/fixtures/modules/structured_data/manifests/init.pp
@@ -1,0 +1,5 @@
+class structured_data($data) {
+  structured_data::def { 'thing':
+    data => $data,
+  }
+}


### PR DESCRIPTION
Puppet internally stringifies all values, which means that rspec
expectations with integers will fail because 1 != "1". This commit adds
a new parameter class, which can recursively validate a parameter and
ensure that structured data will be properly and recursively validated.

This is the first time that I've written any non-trivial amount of code for RSpec, so I have no idea if this is the most idiomatic or clear approach. I would love feedback on how to make this better or more effective.
