### PR TITLE
Improve the run matcher's and_raise_error

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -14,8 +14,15 @@ module RSpec::Puppet
             @func.call
           rescue Exception => e
             @actual_error = e.class
-            if @actual_error == @expected_error
-              result = true
+            if e.is_a?(@expected_error)
+              case @expected_error_message
+              when nil
+                result = true
+              when Regexp
+                result = @expected_error_message =~ e.message
+              else
+                result = @expected_error_message == e.message
+              end
             end
           end
           result
@@ -44,9 +51,13 @@ module RSpec::Puppet
         self
       end
 
-      # XXX support error string and regexp
-      def and_raise_error(value)
-        @expected_error = value
+      def and_raise_error(error_or_message, message=nil)
+        case error_or_message
+        when String, Regexp
+          @expected_error, @expected_error_message = Exception, error_or_message
+        else
+          @expected_error, @expected_error_message = error_or_message, message
+        end
         self
       end
 

--- a/spec/functions/split_spec.rb
+++ b/spec/functions/split_spec.rb
@@ -12,7 +12,19 @@ describe 'split' do
 
   it { should run.with_params('foo').and_raise_error(expected_error) }
 
-  it 'should fail with one argument' do
+  it { should run.with_params('foo').and_raise_error(expected_error, /number of arguments/) }
+
+  it { should run.with_params('foo').and_raise_error(/number of arguments/) }
+
+  it 'should fail with one argument - match exception type' do
     expect { subject.call(['foo']) }.to raise_error(expected_error)
+  end
+
+  it 'should fail with one argument - match exception type and message' do
+    expect { subject.call(['foo']) }.to raise_error(expected_error, /number of arguments/)
+  end
+
+  it 'should fail with one argument - match exception message' do
+    expect { subject.call(['foo']) }.to raise_error(/number of arguments/)
   end
 end


### PR DESCRIPTION
This patch makes the .and_raise_error method of the run matcher behave more like
the built-in rspec `raise_error` matcher.

As a side-effect it softens the requirement on the exception class raised
so that .and_raise_error(/foo/) can shortcut to matching any Exception
class with the correct message.
