### PR TITLE
fixing link to rspec-puppet tarball

### DIFF
--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -21,7 +21,7 @@
         <p class="view"><a href="https://github.com/rodjek/rspec-puppet">View the Project on GitHub <small>rodjek/rspec-puppet</small></a></p>
         <ul>
           <li><a href="https://rubygems.org/gems/rspec-puppet/">Download <strong>Gem</strong></a></li>
-          <li><a href="https://github.com/rspec-puppet/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/rodjek/rspec-puppet/tarball/master">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/rodjek/rspec-puppet">Fork On <strong>GitHub</strong></a></li>
         </ul>
         <p class="view"><a href="/">Home</a></p>


### PR DESCRIPTION
noticed the download tarball link on the homepage was invalid.
