### PR TITLE
Munge actual value into an array if expected value is an array with one item

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -27,6 +27,13 @@ module RSpec::Puppet
         actual   = @resource[@parameter]
         expected = @value
 
+        # Puppet flattens an array with a single value into just the value and
+        # this can cause confusion when testing as people expect when you put
+        # an array in, you'll get an array out.
+        if expected.is_a?(Array) && expected.length == 1
+          actual = Array[actual] unless actual.is_a?(Array)
+        end
+
         retval = check(expected, actual)
 
         unless retval

--- a/spec/hosts/array_spec.rb
+++ b/spec/hosts/array_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'someotherhost' do
+  let(:pre_condition) { <<-EOF
+    define foo($param) {
+    }
+
+    foo { 'bar':
+      param => ['baz'],
+    }
+    EOF
+  }
+
+  it { should contain_foo('bar').with_param(['baz']) }
+end


### PR DESCRIPTION
Puppet flattens parameter values that are an array with a single value down to
just the value.  This causes significant confusion to people who expect to get
an array out if they put an array in.

So, this patch checks if the expected value is an array with only one item in
it and if so, converts the actual value into an array if it's not already one.
