### PR TITLE
Make errors diffable

### DIFF
--- a/lib/rspec-puppet/errors.rb
+++ b/lib/rspec-puppet/errors.rb
@@ -5,16 +5,16 @@ module RSpec::Puppet
 
       def initialize(param, expected, actual, negative)
         @param = param
-        @expected = expected.inspect
-        @actual = actual.inspect
+        @expected = expected
+        @actual = actual
         @negative = negative
       end
 
       def message
         if negative == true
-          "#{param} not set to #{expected} but it is set to #{actual}"
+          "#{param} not set to #{expected.inspect} but it is set to #{actual.inspect}"
         else
-          "#{param} set to #{expected} but it is set to #{actual}"
+          "#{param} set to #{expected.inspect} but it is set to #{actual.inspect}"
         end
       end
 
@@ -26,9 +26,9 @@ module RSpec::Puppet
     class RegexpMatchError < MatchError
       def message
         if negative == true
-          "#{param} not matching #{expected} but its value of #{actual} does"
+          "#{param} not matching #{expected.inspect} but its value of #{actual.inspect} does"
         else
-          "#{param} matching #{expected} but its value of #{actual} does not"
+          "#{param} matching #{expected.inspect} but its value of #{actual.inspect} does not"
         end
       end
     end
@@ -36,9 +36,9 @@ module RSpec::Puppet
     class ProcMatchError < MatchError
       def message
         if negative == true
-          "#{param} passed to the block would not return `#{expected}` but it did"
+          "#{param} passed to the block would not return `#{expected.inspect}` but it did"
         else
-          "#{param} passed to the block would return `#{expected}` but it is `#{actual}`"
+          "#{param} passed to the block would return `#{expected.inspect}` but it is `#{actual.inspect}`"
         end
       end
     end

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -137,6 +137,18 @@ module RSpec::Puppet
         "contain #{@referenced_type}[#{@title}]#{value_str}"
       end
 
+      def diffable?
+        true
+      end
+
+      def expected
+        @errors.map {|e| e.expected if e.respond_to?(:expected)}.compact.join("\n\n")
+      end
+
+      def actual
+        @errors.map {|e| e.actual if e.respond_to?(:actual)}.compact.join("\n\n")
+      end
+
       private
       def referenced_type(type)
         type.split('__').map { |r| r.capitalize }.join('::')


### PR DESCRIPTION
In the case of multiple errors in the same spec it just appends the errors

example

```
 Failure/Error: it { should contain_file(expected_filename).with_content(read_file("populated-mavenrc")) }
   expected that the catalogue would contain File[/home/u/.mavenrc] with content set to "export MAVEN_OPTS=\"-Xmx256m $MAVEN_OPTS\"\nexport PATH=\"/usr/local/bin:$PATH\"\necho Hello World!\ns\n" but it is set to "export MAVEN_OPTS=\"-Xmx256m $MAVEN_OPTS\"\nexport PATH=\"/usr/local/bin:$PATH\"\necho Hello World!\n"
   Diff:
   @@ -1,5 +1,4 @@
    export MAVEN_OPTS="-Xmx256m $MAVEN_OPTS"
    export PATH="/usr/local/bin:$PATH"
    echo Hello World!
   -an extra line
```
