### PR TITLE
Fixing symlink message calling nonexistent variable

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -122,7 +122,7 @@ EOF
     def self.safe_make_symlink(source, target)
       if File.exists? target
         unless File.symlink? target
-          $stderr.puts "!! #{file} already exists and is not a symlink"
+          $stderr.puts "!! #{target} already exists and is not a symlink"
         end
       else
         FileUtils.ln_s(source, target)


### PR DESCRIPTION
The bug was generating this error:

/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rspec-puppet-0.1.6/lib/rspec-puppet/setup.rb:113:in `safe_make_symlink': undefined local variable or method`file' for RSpec::Puppet::Setup:Class (NameError)

Fixed by calling the right parameter.
