### PR TITLE
fix bad syntax in the custom matcher run

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -2,6 +2,7 @@ module RSpec::Puppet
   module FunctionMatchers
     class Run
       def matches?(func_obj)
+        @func_obj = func_obj
         if @params
           @func = lambda { func_obj.call(@params) }
         else
@@ -61,17 +62,21 @@ module RSpec::Puppet
         self
       end
 
-      def failure_message_for_should(func_obj)
-        failure_message_generic(:should, func_obj)
+      def failure_message_for_should
+        failure_message_generic(:should, @func_obj)
       end
 
-      def failure_message_for_should_not(func_obj)
-        failure_message_generic(:should_not, func_obj)
+      def failure_message_for_should_not
+        failure_message_generic(:should_not, @func_obj)
+      end
+
+      def description
+        "run function and match"
       end
 
       private
       def failure_message_generic(type, func_obj)
-        func_name = func_obj.name.gsub(/^function_/, '')
+        func_name = func_obj.name.to_s.gsub(/^function_/, '')
         func_params = @params.inspect[1..-2]
 
         message = "expected #{func_name}(#{func_params}) to "


### PR DESCRIPTION
If you modify the file spec/functions/split_spec.rb and add an extra s to /number of argumentss/, you will find the following failure:
     Failure/Error: it { should run.with_params('foo').and_raise_error(expected_error, /number of argumentss/) }
     ArgumentError:
       wrong number of arguments (0 for 1)
     # ./lib/rspec-puppet/matchers/run.rb:64:in `failure_message_for_should'
     # ./spec/functions/split_spec.rb:15:in`block (2 levels) in <top (required)>'

Indeed the method failure_message_for_should and failure_message_for_should_not do not take any arguments.
the issue has not been seen since it requires a failing test that cannot be teste.

after the fix, the failure is now:
     Failure/Error: it { should run.with_params('foo').and_raise_error(expected_error, /number of argumentss/) }
       expected split("foo") to have raised ArgumentError
     # ./spec/functions/split_spec.rb:15:in `block (2 levels) in <top (required)>'

This is the correct expected message.

I also added a description to the matcher to avoid the rspec warning message

I do not know how to test this kind of situation (failure of a matcher).
