### PR TITLE
Expose 'catalogue' method as consistent API in example groups

### DIFF
--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -3,8 +3,10 @@ module RSpec::Puppet
     include RSpec::Puppet::ManifestMatchers
     include RSpec::Puppet::Support
 
-    def subject
-      @catalogue ||= catalogue(:class)
+    def catalogue
+      @catalogue ||= load_catalogue(:class)
     end
+
+    alias_method :subject, :catalogue
   end
 end

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -3,8 +3,10 @@ module RSpec::Puppet
     include RSpec::Puppet::ManifestMatchers
     include RSpec::Puppet::Support
 
-    def subject
-      @catalogue ||= catalogue(:define)
+    def catalogue
+      @catalogue ||= load_catalogue(:define)
     end
+
+    alias_method :subject, :catalogue
   end
 end

--- a/lib/rspec-puppet/example/host_example_group.rb
+++ b/lib/rspec-puppet/example/host_example_group.rb
@@ -3,8 +3,10 @@ module RSpec::Puppet
     include RSpec::Puppet::ManifestMatchers
     include RSpec::Puppet::Support
 
-    def subject
-      @catalogue ||= catalogue(:host)
+    def catalogue
+      @catalogue ||= load_catalogue(:host)
     end
+
+    alias_method :subject, :catalogue
   end
 end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -3,7 +3,7 @@ module RSpec::Puppet
 
     @@cache = {}
 
-    def catalogue(type)
+    def load_catalogue(type)
       vardir = setup_puppet
 
       code = [import_str, pre_cond, test_manifest(type)].join("\n")

--- a/spec/classes/test_api.rb
+++ b/spec/classes/test_api.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'test::bare_class' do
+  describe 'rspec group' do
+    it 'should have a catalogue method' do
+      catalogue.should be_a(Puppet::Resource::Catalog)
+    end
+
+    it 'subject should return a catalogue' do
+      subject.should be_a(Puppet::Resource::Catalog)
+    end
+
+    describe 'derivative group' do
+      subject { catalogue.resource('Notify', 'foo') }
+
+      it 'can redefine subject' do
+        subject.should be_a(Puppet::Resource)
+      end
+    end
+  end
+end

--- a/spec/defines/test_api.rb
+++ b/spec/defines/test_api.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'sysctl' do
+  let(:title) { 'vm.swappiness' }
+  let(:params) { {:value => '60'} }
+
+  describe 'rspec group' do
+    it 'should have a catalogue method' do
+      catalogue.should be_a(Puppet::Resource::Catalog)
+    end
+
+    it 'subject should return a catalogue' do
+      subject.should be_a(Puppet::Resource::Catalog)
+    end
+  end
+end

--- a/spec/hosts/test_api.rb
+++ b/spec/hosts/test_api.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'foo.example.com' do
+  describe 'rspec group' do
+    it 'should have a catalogue method' do
+      catalogue.should be_a(Puppet::Resource::Catalog)
+    end
+
+    it 'subject should return a catalogue' do
+      subject.should be_a(Puppet::Resource::Catalog)
+    end
+  end
+end


### PR DESCRIPTION
In rspec-puppet pre-1.0, the catalogue method was available in all example groups with no arguments.  This has been restored, so the catalogue is easily accessible in derivative example groups where subject is overridden (e.g. so subject can be redefined as a resource inside the catalogue).

I don't think without this there's an easy way to get at the catalogue without knowing the parent example group type (class, define, host).
