### PR TITLE
Removed cache to ensure catalog run for test

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -1,8 +1,6 @@
 module RSpec::Puppet
   module Support
 
-    @@cache = {}
-
     def catalogue(type)
       vardir = setup_puppet
 
@@ -147,7 +145,7 @@ module RSpec::Puppet
     end
 
     def build_catalog(*args)
-      @@cache[args] ||= self.build_catalog_without_cache(*args)
+      self.build_catalog_without_cache(*args)
     end
 
     def munge_facts(facts)


### PR DESCRIPTION
Small description of my issue http://pastebin.com/pYThTvnz

I believe the catalog should be rerun every time unless specified to be cached, which can be of use when testing large code bases. 

A better solution would be to add a setting and sensible defaults for each type of test (function,class,host etc)
