### PR TITLE
Better relationship matcher errors

### DIFF
--- a/lib/rspec-puppet/errors.rb
+++ b/lib/rspec-puppet/errors.rb
@@ -58,25 +58,25 @@ module RSpec::Puppet
 
     class BeforeRelationshipError < RelationshipError
       def message
-        "#{from} to come before #{to} in the graph"
+        "that comes before #{to}"
       end
     end
 
     class RequireRelationshipError < RelationshipError
       def message
-        "#{from} to require #{to} in the graph"
+        "that requires #{to}"
       end
     end
 
     class NotifyRelationshipError < RelationshipError
       def message
-        "#{from} to notify #{to}"
+        "that notifies #{to}"
       end
     end
 
     class SubscribeRelationshipError < RelationshipError
       def message
-        "#{from} to be subscribed to #{to}"
+        "that is subscribed to #{to}"
       end
     end
   end

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -199,17 +199,25 @@ module RSpec::Puppet
       end
 
       def precedes?(first, second)
-        before_refs = relationship_refs(first[:before])
-        require_refs = relationship_refs(second[:require])
+        if first.nil? || second.nil?
+          false
+        else
+          before_refs = relationship_refs(first[:before])
+          require_refs = relationship_refs(second[:require])
 
-        before_refs.include?(second.to_ref) || require_refs.include?(first.to_ref)
+          before_refs.include?(second.to_ref) || require_refs.include?(first.to_ref)
+        end
       end
 
       def notifies?(first, second)
-        notify_refs = relationship_refs(first[:notify])
-        subscribe_refs = relationship_refs(second[:subscribe])
+        if first.nil? || second.nil?
+          false
+        else
+          notify_refs = relationship_refs(first[:notify])
+          subscribe_refs = relationship_refs(second[:subscribe])
 
-        notify_refs.include?(second.to_ref) || subscribe_refs.include?(first.to_ref)
+          notify_refs.include?(second.to_ref) || subscribe_refs.include?(first.to_ref)
+        end
       end
 
       # @param resource [Hash<Symbol, Object>] The resource in the catalog


### PR DESCRIPTION
Previously, if testing a relationship with the `that_*` matchers and the named resource didn't exist, rspec-puppet would throw a nasty missing method error on nil.
