### PR TITLE
add catalogue method to function example group

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -11,14 +11,6 @@ module RSpec::Puppet
 
       node_name = nodename(:function)
 
-      facts_val = facts_hash(node_name)
-
-      # if we specify a pre_condition, we should ensure that we compile that code
-      # into a catalog that is accessible from the scope where the function is called
-      Puppet[:code] = pre_cond
-
-      compiler = build_compiler(node_name, facts_val)
-
       function_scope = scope(compiler, node_name)
 
       # Return the method instance for the function.  This can be used with
@@ -28,8 +20,26 @@ module RSpec::Puppet
       function_scope.method("function_#{function_name}".intern)
     end
 
+    def catalogue
+      @catalogue ||= compiler.catalog
+    end
+
+    private
+
+    def compiler
+      @compiler ||= build_compiler
+    end
+
     # get a compiler with an attached compiled catalog
-    def build_compiler(node_name, fact_values)
+    def build_compiler
+      node_name   = nodename(:function)
+      fact_values = facts_hash(node_name)
+
+      # if we specify a pre_condition, we should ensure that we compile that
+      # code into a catalog that is accessible from the scope where the
+      # function is called
+      Puppet[:code] = pre_cond
+
       node_options = {
         :parameters => fact_values,
       }

--- a/spec/functions/catalogue_spec.rb
+++ b/spec/functions/catalogue_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'split' do
+  describe 'rspec group' do
+    it 'should have a catalogue method' do
+      catalogue.should be_a(Puppet::Resource::Catalog)
+    end
+
+    it 'catalogue should not change after subject is called' do
+      catalogue.should be_a(Puppet::Resource::Catalog)
+      pre_id = catalogue.object_id
+
+      should run.with_params('aoeu', 'o').and_return(['a', 'eu'])
+
+      post_id = catalogue.object_id
+
+      pre_id.should eq post_id
+    end
+  end
+end


### PR DESCRIPTION
This brings the function example group into line with the
class/define/host example groups.  Having access to the catalog in this
context is particularly useful for testing functions that create
resources. Eg.

```
it 'should work make a stooge resource' do
  should run.with_params('larry')

  larry = catalogue.resource('Stooge' 'larry')
  larry[:hates].should eq 'knock knock jokes'
end
```
