### PR TITLE
Allow overriding node name in host spec

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -69,8 +69,9 @@ module RSpec::Puppet
     end
 
     def nodename(type)
+      return node if self.respond_to?(:node)
       if [:class, :define, :function].include? type
-        self.respond_to?(:node) ? node : Puppet[:certname]
+        Puppet[:certname]
       else
         self.class.top_level_description.downcase
       end

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -2,6 +2,10 @@ node default {
   notify { 'test': }
 }
 
+node 'testhost_a' {
+  file { '/tmp/a': }
+}
+
 node /testhost/ {
   include sysctl::common
 }

--- a/spec/hosts/testhost_spec.rb
+++ b/spec/hosts/testhost_spec.rb
@@ -2,4 +2,10 @@ require 'spec_helper'
 
 describe 'testhost' do
   it { should contain_class('sysctl::common') }
+
+  describe 'testhost_a' do
+    let(:node) { 'testhost_a' }
+    it { should_not contain_class('sysctl::common') }
+    it { should contain_file('/tmp/a') }
+  end
 end


### PR DESCRIPTION
Allow describing several hosts in the same spec file if node is overriden, useful if they share some common behavior.
