### PR TITLE
Add data to the list of symlinked dirs in init

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -31,7 +31,7 @@ module RSpec::Puppet
 
       safe_touch('spec/fixtures/manifests/site.pp')
 
-      ['manifests','lib','files','templates'].each do |dir|
+      %w(data manifests lib files templates).each do |dir|
         if File.exist? dir
           safe_make_symlink("../../../../#{dir}", "spec/fixtures/modules/#{module_name}/#{dir}")
         end


### PR DESCRIPTION
A lot of folks use the module-data module, which uses data for storing per-module hierdata. Let's support that for these folks.
