### PR TITLE
ensure better error message when expecting an Array, but the content defined is nil

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -100,6 +100,10 @@ module RSpec::Puppet
       def check_array(expected, actual)
         op = @should_match ? :"==" : :"!="
 
+        # fix also the case where actual is nil (to have more explicit error
+        # message than NoMethodError: undefined method `size' for nil:NilClass)
+        return false if actual.nil?
+        
         unless expected.size.send(op, actual.size)
           return false
         end


### PR DESCRIPTION
In case we expect an Array, but in manifest nothing is defined we currently have a useless error message: "NoMethodError: undefined method `size' for nil:NilClass".

This patch allow to have the real underlying error message by preventing the call to nil.size.

I did not find a way to add a test to cover this case. in case you have way to do so, I'll be happy to get info on how to do it.

Could you also bump the version and publish a new gem since it has not be been done for a while now ?

Thanks.
