### PR TITLE
"rake rspec" fails when spec/spec.opts does not exist

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -137,7 +137,11 @@ require 'rspec/core/rake_task'
 
 desc "Run all RSpec code examples"
 RSpec::Core::RakeTask.new(:rspec) do |t|
-  t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+  begin
+    t.rspec_opts = File.read("spec/spec.opts").chomp
+  rescue Errno::ENOENT
+    t.rspec_opts = ""
+  end
 end
 
 SPEC_SUITES = (Dir.entries('spec') - ['.', '..','fixtures']).select {|e| File.directory? "spec/#{e}" }


### PR DESCRIPTION
After running ```rspec-puppet-init```, I'm getting this failure:
```
$ bundle exec rake rspec
rake aborted!
No such file or directory - spec/spec.opts
/home/me/my_module/Rakefile:6:in `read'
/home/me/my_module/Rakefile:6:in `block in <top (required)>'
/home/me/.gem/ruby/2.0.0/gems/rspec-core-2.14.7/lib/rspec/core/rake_task.rb:122:in `call'
/home/me/.gem/ruby/2.0.0/gems/rspec-core-2.14.7/lib/rspec/core/rake_task.rb:122:in `block (2 levels) in initialize'
/home/me/.gem/ruby/2.0.0/gems/rspec-core-2.14.7/lib/rspec/core/rake_task.rb:121:in `block in initialize'
Tasks: TOP => rspec
(See full trace by running task with --trace)
```

The problem is on line 140 of lib/rspec-puppet/setup.rb.  It's expecting ```File.read("spec/spec.opts")``` to return false if the file does not exist, but that actually raises an exception.

```
[1] pry(main)> File.read('/does/not/exist')
Errno::ENOENT: No such file or directory - /does/not/exist
from (pry):1:in `read'
```