### PR TITLE
Fixes bug when spec/spec.ops missing

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -137,7 +137,8 @@ require 'rspec/core/rake_task'
 
 desc "Run all RSpec code examples"
 RSpec::Core::RakeTask.new(:rspec) do |t|
-  t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+  File.exist?('spec/spec.opts') ? opts = File.read("spec/spec.opts").chomp : opts = ""
+  t.rspec_opts = opts
 end
 
 SPEC_SUITES = (Dir.entries('spec') - ['.', '..','fixtures']).select {|e| File.directory? "spec/#{e}" }
@@ -146,7 +147,8 @@ namespace :rspec do
     desc "Run #{suite} RSpec code examples"
     RSpec::Core::RakeTask.new(suite) do |t|
       t.pattern = "spec/#{suite}/**/*_spec.rb"
-      t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+      File.exist?('spec/spec.opts') ? opts = File.read("spec/spec.opts").chomp : opts = ""
+      t.rspec_opts = opts
     end
   end
 end


### PR DESCRIPTION
Previous code would cause the issue:
````
rake aborted!
No such file or directory - spec/spec.opts
```

With this change, if the file doesn't exist, the opts will be empty, and the rake will run as expected.