### PR TITLE
Make parser configurable.

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -22,6 +22,7 @@ RSpec.configure do |c|
   c.add_setting :confdir, :default => '/etc/puppet'
   c.add_setting :default_facts, :default => {}
   c.add_setting :hiera_config, :default => '/dev/null'
+  c.add_setting :parser, :default => 'current'
 
   if defined?(Puppet::Test::TestHelper)
     begin

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -123,6 +123,7 @@ module RSpec::Puppet
         [:config, :config],
         [:confdir, :confdir],
         [:hiera_config, :hiera_config],
+        [:parser, :parser],
       ].each do |a, b|
         value = self.respond_to?(b) ? self.send(b) : RSpec.configuration.send(b)
         begin


### PR DESCRIPTION
Fixes #182.

I think this is all it takes. I did a run with `c.parser = future` with Puppet 3.5.0.rc1 and used the new type system, everything worked and passed.
