### PR TITLE
Only show the "Untouched resources" stanza when untouched resources exist

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -48,15 +48,19 @@ module RSpec::Puppet
         Total resources:   #{report[:total]}
         Touched resources: #{report[:touched]}
         Resource coverage: #{report[:coverage]}%
-
-        Untouched resources:
-
-        #{
-          report[:detailed].select { |_, resource| !resource["touched"]}.map do |name, resource|
-            "  #{name}"
-          end.flatten.join("\n")
-        }
       EOH
+
+      if report[:coverage] != "100.00"
+        puts <<-EOH.gsub(/^ {10}/, '')
+          Untouched resources:
+
+          #{
+            report[:detailed].select { |_, resource| !resource["touched"]}.map do |name, resource|
+              "  #{name}"
+            end.flatten.join("\n")
+          }
+        EOH
+      end
 
     end
 


### PR DESCRIPTION
The "Untouched resources" details should only be displayed if untouched resources are found.
