### PR TITLE
Add support for setting the ordering option.

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -23,6 +23,7 @@ RSpec.configure do |c|
   c.add_setting :default_facts, :default => {}
   c.add_setting :hiera_config, :default => '/dev/null'
   c.add_setting :parser, :default => 'current'
+  c.add_setting :ordering, :default => 'title-hash'
 
   if defined?(Puppet::Test::TestHelper)
     begin

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -124,6 +124,7 @@ module RSpec::Puppet
         [:confdir, :confdir],
         [:hiera_config, :hiera_config],
         [:parser, :parser],
+        [:ordering, :ordering],
       ].each do |a, b|
         value = self.respond_to?(b) ? self.send(b) : RSpec.configuration.send(b)
         begin

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -13,10 +13,19 @@ describe RSpec::Puppet::Support do
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("current")
     end
+    it 'sets Puppet[:ordering] to "title-hash" by default' do
+      subject.setup_puppet
+      expect(Puppet[:ordering]).to eq("title-hash")
+    end
     it 'reads the :parser setting' do
       allow(subject).to receive(:parser).and_return("future")
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("future")
+    end
+    it 'reads the :ordering setting' do
+      allow(subject).to receive(:ordering).and_return("random")
+      subject.setup_puppet
+      expect(Puppet[:ordering]).to eq("random")
     end
   end
 end


### PR DESCRIPTION
As per http://puppetlabs.com/blog/introducing-manifest-ordered-resources it's possible to set the ordering to one of three modes:
- `title-hash`, the current default of Puppet;
- `manifest`, the default per Puppet 4;
- `random`, should be used for tests to catch ordering issues.

Though I would prefer to set the default to `random` as that is the most valuable setting for testing I'm afraid that will trip too many people up, especially with Puppet's default changing to `manifest` in Puppet 4
as per https://github.com/puppetlabs/puppet/commit/9962f4a872b8412d04f16fdfd9e77789d02f7e84
