### PR TITLE
Fixes incompatibility with RSpec 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
-rspecversion = ENV.key?('RSPEC_VERSION') ? "= #{ENV['RSPEC_VERSION']}" : ['>= 2.9']
+rspecversion = ENV.key?('RSPEC_VERSION') ? "= #{ENV['RSPEC_VERSION']}" : ['>= 2.9 ', '< 3.0.0']
 
 gem 'rake'
 gem 'rspec', rspecversion

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -15,7 +15,7 @@ module RSpec::Puppet
 
       catalogue = build_catalog(node_name, facts_hash(node_name), code)
 
-      RSpec::Puppet::Coverage.filters << "#{type.to_s.capitalize}[#{self.class.display_name.capitalize}]"
+      RSpec::Puppet::Coverage.filters << "#{type.to_s.capitalize}[#{self.class.description.capitalize}]"
 
       catalogue.to_a.each do |resource|
         RSpec::Puppet::Coverage.add(resource)

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['LICENSE.md', 'README.md', 'lib/**/*', 'bin/**/*']
 
-  s.add_dependency 'rspec'
+  s.add_dependency 'rspec', '< 3.0.0'
 
   s.authors = ['Tim Sharpe']
   s.email = 'tim@sharpe.id.au'


### PR DESCRIPTION
- Pin rspec dependency to < 3.0.0 Fixes #200
- Fix deprecation warnings related to 'display_name', fixes #198

Same solution as #199 but also pins rspec-puppet to RSpec < 3.0.0 as there are likely numerous other issues people will face when depending on rspec-puppet to pull in the necessary rspec dependencies. 
