### PR TITLE
Check that Puppet[:manifest] exists before importing it

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -39,7 +39,7 @@ module RSpec::Puppet
           "import '#{path_to_manifest}.pp'",
           '',
         ].join("\n")
-      elsif File.exists?(Puppet[:modulepath])
+      elsif File.exists?(Puppet[:manifest])
         import_str = "import '#{Puppet[:manifest]}'\n"
       else
         import_str = ""


### PR DESCRIPTION
Currently it is checked if `Puppet[:modulepath]` exists before importing `Puppet[:manifest]`. This causes problems if `Puppet[:modulepath]` contains several paths (separated by `:`).

Handling multiple module paths correctly probably requires changes in several places, but while I started to look into it, I stumbled across this line, which didn't make sense to me.

Please feel free to reject this pull request if there is a good reason to check for the existence of `Puppet[:modulepath]` that I didn't comprehend.