### PR TITLE
Set Puppet[:libdir] correctly if Puppet[:modulepath] contains multiple paths

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -133,7 +133,9 @@ module RSpec::Puppet
         end
       end
 
-      Puppet[:libdir] = Dir["#{Puppet[:modulepath]}/*/lib"].entries.join(File::PATH_SEPARATOR)
+      Puppet[:libdir] = Puppet[:modulepath].split(File::PATH_SEPARATOR).map { |d|
+        Dir["#{d}/*/lib"].entries
+      }.flatten.join(File::PATH_SEPARATOR)
       vardir
     end
 


### PR DESCRIPTION
When the `Puppet[:modulepath]` contains several paths (separated by `:`), the `Puppet[:libdir]` is currently not set at all, causing e.g. custom functions not to be loaded.

With this patch, the `lib` subdirectories of modules from all `modulepath` entries are added to the `libdir`.