### PR TITLE
Allow tests to have strict variables

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -23,6 +23,7 @@ RSpec.configure do |c|
   c.add_setting :default_facts, :default => {}
   c.add_setting :hiera_config, :default => '/dev/null'
   c.add_setting :parser, :default => 'current'
+  c.add_setting :strict_variables, :default => false
 
   if defined?(Puppet::Test::TestHelper)
     begin

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -124,6 +124,7 @@ module RSpec::Puppet
         [:confdir, :confdir],
         [:hiera_config, :hiera_config],
         [:parser, :parser],
+        [:strict_variables, :strict_variables],
       ].each do |a, b|
         value = self.respond_to?(b) ? self.send(b) : RSpec.configuration.send(b)
         begin

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -18,5 +18,14 @@ describe RSpec::Puppet::Support do
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("future")
     end
+    it 'sets Puppet[:strict_variables] to false by default' do
+      subject.setup_puppet
+      expect(Puppet[:strict_variables]).to eq(false)
+    end
+    it 'reads the :strict_variables setting' do
+      allow(subject).to receive(:strict_variables).and_return(true)
+      subject.setup_puppet
+      expect(Puppet[:strict_variables]).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
Similar to how the future parser ability works, this will allow catalogs
to be compiled with strict variable parsing turned on.