### PR TITLE
Add support for puppet3.6 config options trusted_node_data, ordering, st...

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -23,6 +23,9 @@ RSpec.configure do |c|
   c.add_setting :default_facts, :default => {}
   c.add_setting :hiera_config, :default => '/dev/null'
   c.add_setting :parser, :default => 'current'
+  c.add_setting :trusted_node_data, :default => false
+  c.add_setting :ordering, :default => 'title-hash'
+  c.add_setting :stringify_facts, :default => true
 
   if defined?(Puppet::Test::TestHelper)
     begin

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -124,6 +124,9 @@ module RSpec::Puppet
         [:confdir, :confdir],
         [:hiera_config, :hiera_config],
         [:parser, :parser],
+        [:trusted_node_data, :trusted_node_data],
+        [:ordering, :ordering],
+        [:stringify_facts, :stringify_facts],
       ].each do |a, b|
         value = self.respond_to?(b) ? self.send(b) : RSpec.configuration.send(b)
         begin

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -18,5 +18,32 @@ describe RSpec::Puppet::Support do
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("future")
     end
+    it 'sets Puppet[:trusted_node_data] to false by default' do
+      subject.setup_puppet
+      expect(Puppet[:trusted_node_data]).to eq(false)
+    end
+    it 'reads the :trusted_node_data setting' do
+      allow(subject).to receive(:trusted_node_data).and_return(true)
+      subject.setup_puppet
+      expect(Puppet[:trusted_node_data]).to eq(true)
+    end
+    it 'sets Puppet[:stringify_facts] to true by default' do
+      subject.setup_puppet
+      expect(Puppet[:stringify_facts]).to eq(true)
+    end
+    it 'reads the :stringify_facts setting' do
+      allow(subject).to receive(:stringify_facts).and_return(false)
+      subject.setup_puppet
+      expect(Puppet[:stringify_facts]).to eq(false)
+    end
+    it 'sets Puppet[:ordering] to title-hash by default' do
+      subject.setup_puppet
+      expect(Puppet[:ordering]).to eq('title-hash')
+    end
+    it 'reads the :ordering setting' do
+      allow(subject).to receive(:ordering).and_return('manifest')
+      subject.setup_puppet
+      expect(Puppet[:ordering]).to eq('manifest')
+    end
   end
 end


### PR DESCRIPTION
...ringify_facts

This effectively follows up on https://github.com/rodjek/rspec-puppet/pull/183 and the not-yet-merged https://github.com/rodjek/rspec-puppet/pull/209 by adding support for the rest of the parser-altering settings added in 3.6, specifically the three listed as "recommended and safe" (http://docs.puppetlabs.com/puppet/3.6/reference/config_important_settings.html#getting-new-features-early). ``ordering`` could prove quite useful, but the important part here is ``trusted_node_data`` which actually introduces two reserved variables, ``$facts`` and ``$trusted`` (see http://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html). This will prove valuable for modules (perhaps it should even be set to true by default?), since as it stands now, puppet4 will introduce these variables and likely break any modules that happen to use them.