### PR TITLE
Skip 'import' statements when parser = future

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -10,7 +10,12 @@ module RSpec::Puppet
     def load_catalogue(type)
       vardir = setup_puppet
 
-      code = [import_str, pre_cond, test_manifest(type)].join("\n")
+      if Puppet[:parser] == 'future'
+        code = [pre_cond, test_manifest(type)].join("\n")
+      else
+        code = [import_str, pre_cond, test_manifest(type)].join("\n")
+      end
+
       node_name = nodename(type)
 
       catalogue = build_catalog(node_name, facts_hash(node_name), code)


### PR DESCRIPTION
As mentioned in https://github.com/rodjek/rspec-puppet/issues/196#issuecomment-54631457, this looks to fix rspec-puppet when the future parser is used. I tested a module using Puppet 3.2, 3.5 and 3.7, and since the default is to leave behavior default when `parser != future` this shouldn't affect any existing tests when using the default parser.

If spec tests are required I'll need some help; I'm not sure how best to test the `load_catalogue` method that the code has updated.

Fixes #196 
