### PR TITLE
Fix import_str for multiple module paths

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -28,22 +28,25 @@ module RSpec::Puppet
     def import_str
       klass_name = self.class.top_level_description.downcase
 
-      if File.exists?(File.join(Puppet[:modulepath], 'manifests', 'init.pp'))
-        path_to_manifest = File.join([
-          Puppet[:modulepath],
-          'manifests',
-          klass_name.split('::')[1..-1]
-        ].flatten)
-        import_str = [
-          "import '#{Puppet[:modulepath]}/manifests/init.pp'",
-          "import '#{path_to_manifest}.pp'",
-          '',
-        ].join("\n")
-      elsif File.exists?(Puppet[:modulepath])
-        import_str = "import '#{Puppet[:manifest]}'\n"
-      else
-        import_str = ""
-      end
+      import_str = ""
+      Puppet[:modulepath].split(File::PATH_SEPARATOR).each { |d|
+        if File.exists?(File.join(d, 'manifests', 'init.pp'))
+          path_to_manifest = File.join([
+            d,
+            'manifests',
+            klass_name.split('::')[1..-1]
+          ].flatten)
+          import_str = [
+            "import '#{d}/manifests/init.pp'",
+            "import '#{path_to_manifest}.pp'",
+            '',
+          ].join("\n")
+          break
+        elsif File.exists?(d)
+          import_str = "import '#{Puppet[:manifest]}'\n"
+          break
+        end
+      }
 
       import_str
     end
@@ -133,7 +136,9 @@ module RSpec::Puppet
         end
       end
 
-      Puppet[:libdir] = Dir["#{Puppet[:modulepath]}/*/lib"].entries.join(File::PATH_SEPARATOR)
+      Puppet[:libdir] = Puppet[:modulepath].split(File::PATH_SEPARATOR).map { |d|
+        Dir["#{d}/*/lib"].entries
+      }.flatten.join(File::PATH_SEPARATOR)
       vardir
     end
 


### PR DESCRIPTION
import_str does not handle multiple module paths, this can result in false positives, where import is never actually called.