### PR TITLE
Reduce file content on summary

### DIFF
--- a/lib/rspec-puppet/errors.rb
+++ b/lib/rspec-puppet/errors.rb
@@ -11,10 +11,18 @@ module RSpec::Puppet
       end
 
       def message
-        if negative == true
-          "#{param} not set to #{expected.inspect} but it is set to #{actual.inspect}"
+        if @param.to_s == 'content'
+          if negative == true
+            "#{param} not set to #{expected.lines.first} ... but it is set to #{actual.lines.first} ..."
+          else
+            "#{param} set to #{expected.lines.first} ... but it is set to #{actual.lines.first} ..."
+          end
         else
-          "#{param} set to #{expected.inspect} but it is set to #{actual.inspect}"
+          if negative == true
+            "#{param} not set to #{expected.inspect} but it is set to #{actual.inspect}"
+          else
+            "#{param} set to #{expected.inspect} but it is set to #{actual.inspect}"
+          end
         end
       end
 

--- a/lib/rspec-puppet/errors.rb
+++ b/lib/rspec-puppet/errors.rb
@@ -13,9 +13,9 @@ module RSpec::Puppet
       def message
         if @param.to_s == 'content'
           if negative == true
-            "#{param} not set to #{expected.lines.first} ... but it is set to #{actual.lines.first} ..."
+            "#{param} not set to #{expected.lines.first.chomp} ... but it is set to #{actual.lines.first.chomp} ..."
           else
-            "#{param} set to #{expected.lines.first} ... but it is set to #{actual.lines.first} ..."
+            "#{param} set to #{expected.lines.first.chomp} ... but it is set to #{actual.lines.first.chomp} ..."
           end
         else
           if negative == true

--- a/lib/rspec-puppet/errors.rb
+++ b/lib/rspec-puppet/errors.rb
@@ -11,7 +11,7 @@ module RSpec::Puppet
       end
 
       def message
-        if @param.to_s == 'content'
+        if @param.to_s == 'content' and expected.is_a?( String )
           if negative == true
             "#{param} not set to #{expected.lines.first.chomp} ... but it is set to #{actual.lines.first.chomp} ..."
           else

--- a/lib/rspec-puppet/errors.rb
+++ b/lib/rspec-puppet/errors.rb
@@ -13,9 +13,9 @@ module RSpec::Puppet
       def message
         if @param.to_s == 'content' and expected.is_a?( String )
           if negative == true
-            "#{param} not set to #{expected.lines.first.chomp} ... but it is set to #{actual.lines.first.chomp} ..."
+            "#{param} not set to supplied string"
           else
-            "#{param} set to #{expected.lines.first.chomp} ... but it is set to #{actual.lines.first.chomp} ..."
+            "#{param} set to supplied string"
           end
         else
           if negative == true

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -168,7 +168,7 @@ module RSpec::Puppet
           else
             a = type == :not ? '!' : '='
             b = value.is_a?(Regexp) ? '~' : '>'
-            if param.to_s == 'content'
+            if param.to_s == 'content' and value.is_a?( String )
               output << "#{param.to_s} #{a}#{b} #{value.lines.first.chomp} ..."
             else
               output << "#{param.to_s} #{a}#{b} #{value.inspect}"

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -168,7 +168,11 @@ module RSpec::Puppet
           else
             a = type == :not ? '!' : '='
             b = value.is_a?(Regexp) ? '~' : '>'
-            output << "#{param.to_s} #{a}#{b} #{value.inspect}"
+            if param.to_s == 'content'
+              output << "#{param.to_s} #{a}#{b} #{value.lines.first.chomp} ..."
+            else
+              output << "#{param.to_s} #{a}#{b} #{value.inspect}"
+            end
           end
         end
         output

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -169,7 +169,7 @@ module RSpec::Puppet
             a = type == :not ? '!' : '='
             b = value.is_a?(Regexp) ? '~' : '>'
             if param.to_s == 'content' and value.is_a?( String )
-              output << "#{param.to_s} #{a}#{b} #{value.lines.first.chomp} ..."
+              output << "#{param.to_s} #{type == :not ? 'not ' : ''} supplied string"
             else
               output << "#{param.to_s} #{a}#{b} #{value.inspect}"
             end


### PR DESCRIPTION
When the file content fails the check, the whole content of both files is shown in the summary line. This PR makes that only their leading lines get shown, to make the summary readable.