### PR TITLE
travis: Trim down the matrix, simplify versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 rvm:
   - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
@@ -10,47 +9,28 @@ rvm:
 sudo: false
 
 env:
-  - PUPPET_VERSION=2.6.18
-  - PUPPET_VERSION=2.7.23
-  - PUPPET_VERSION=3.0.2
-  - PUPPET_VERSION=3.1.1
-  - PUPPET_VERSION=3.2.4
-  - PUPPET_VERSION=3.3.2
-  - PUPPET_VERSION=3.4.3
-  - PUPPET_VERSION=3.5.1
-  - PUPPET_VERSION=4.0.0
+  - PUPPET_VERSION=2.7
+  - PUPPET_VERSION=3.2
+  - PUPPET_VERSION=3.4
+  - PUPPET_VERSION=3.6
+  - PUPPET_VERSION=3.7
+  - PUPPET_VERSION=4.0
   - RSPEC_VERSION=2.14
 
 matrix:
   exclude:
     - rvm: 1.8.7
-      env: PUPPET_VERSION=4.0.0
-    - rvm: 1.9.2
-      env: PUPPET_VERSION=2.6.18
-    - rvm: 1.9.2
-      env: PUPPET_VERSION=4.0.0
+      env: RSPEC_VERSION=2.14
+    - rvm: 1.8.7
+      env: PUPPET_VERSION=4.0
     - rvm: 1.9.3
-      env: PUPPET_VERSION=2.6.18
+      env: PUPPET_VERSION=2.7
     - rvm: 2.0.0
-      env: PUPPET_VERSION=2.6.18
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=2.7.23
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=3.0.2
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=3.1.1
+      env: PUPPET_VERSION=2.7
     - rvm: 2.1
-      env: PUPPET_VERSION=2.6.18
+      env: PUPPET_VERSION=2.7
     - rvm: 2.1
-      env: PUPPET_VERSION=2.7.23
-    - rvm: 2.1
-      env: PUPPET_VERSION=3.0.2
-    - rvm: 2.1
-      env: PUPPET_VERSION=3.1.1
-    - rvm: 2.1
-      env: PUPPET_VERSION=3.2.4
-    - rvm: 2.1
-      env: PUPPET_VERSION=3.3.2
+      env: PUPPET_VERSION=3.2
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,7 @@
 source 'https://rubygems.org'
 
-if ENV['PUPPET_VERSION']
-  puppetversion = "= #{ENV['PUPPET_VERSION']}"
-else
-  puppetversion = '~> 3.0'
-end
-
-if ENV['RSPEC_VERSION']
-  rspecversion = "= #{ENV['RSPEC_VERSION']}"
-else
-  rspecversion = '~> 2.0'
-end
+puppetversion = ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}.0" : ['~> 4.0']
+rspecversion = ENV.key?('RSPEC_VERSION') ? "= #{ENV['RSPEC_VERSION']}" : ['~> 2.0']
 
 gem 'rake'
 gem 'rspec', rspecversion


### PR DESCRIPTION
* Throw away anything relating to Puppet 2.6
* Build on 2.7 but not on too modern Ruby versions
* Build on 3.2, 3.4 and 3.6 because of PE
  * PE 3.0 -> OSS 3.2
  * PE 3.1 -> OSS 3.4
  * PE 3.3 -> OSS 3.6
* Build on latest OSS, 3.7.x
  * PE 3.7 -> OSS 3.7

By using the pessimistic version operator, `~>` we can simply specify `2.7.0` and be sure that we'll get the latest version in the 2.7.X series.

Ruby 1.9.2 was never supported by Puppet Labs, no need to test for it and Puppet 2.7 was never supported on Ruby 1.9.3+, as per: https://docs.puppetlabs.com/guides/platforms.html