### PR TITLE
Set $LOAD_PATH instead of puppet's libdir

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -127,6 +127,7 @@ module RSpec::Puppet
 
       if Puppet.version.to_f >= 4.0
         settings = [
+          [:modulepath, :module_path],
           [:environmentpath, :environmentpath],
           [:config, :config],
           [:confdir, :confdir],
@@ -153,8 +154,10 @@ module RSpec::Puppet
         end
       end
 
-      # This line is wrong. libdir should never be more than a single path
-      Puppet[:libdir] = Dir["#{Puppet[:modulepath]}/*/lib"].entries.join(File::PATH_SEPARATOR)
+      Dir["#{Puppet[:modulepath]}/*/lib"].entries.each do |lib|
+        $LOAD_PATH << lib
+      end
+
       vardir
     end
 

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -18,5 +18,18 @@ describe RSpec::Puppet::Support do
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("future")
     end
+    it 'updates the ruby $LOAD_PATH based on the current modulepath' do
+      basedir = '/mymodulepath'
+      RSpec.configuration.module_path = basedir
+
+      dira = File.join(basedir, 'a', 'lib')
+      dirb = File.join(basedir, 'b', 'lib')
+      allow(Dir).to receive(:[]).with("#{basedir}/*/lib").and_return([dira, dirb])
+
+      subject.setup_puppet
+
+      expect($LOAD_PATH).to include(dira)
+      expect($LOAD_PATH).to include(dirb)
+    end
   end
 end


### PR DESCRIPTION
Commit 7f7e74f02c set puppet's `libdir` to include the lib directory for
each module in the `modulepath`. Doing so enabled puppet's autoloader to
load modules that hadn't been pluginsynced. However, this only worked for
code that the autoloader directly loaded. It didn't work when the
autoloaded type, provider, etc required helper code in the same module,
or different module, because the module's lib directory was not in ruby's
$LOAD_PATH.

The commit also relied on inconsistent behavior in puppet whereby sometimes
puppet assumed `libdir` was a (semi)colon separated list of directories, and
sometimes it assumed a single directory. In Puppet 4.0, puppet will
only interpret the `libdir` setting as a single directory[1].

As a result, this commit stops setting `libdir` and instead updates the
ruby $LOAD_PATH. In doing so, rspec-puppet is the "application" the uses
puppet as a "library". In that pattern, rspec-puppet is the thing that
sets the ruby $LOAD_PATH, and puppet just uses the specified $LOAD_PATH.
This is similar to how we fixed loading faces from modules[2] in commit[3].

[1] https://tickets.puppetlabs.com/browse/PUP-3336
[2] https://projects.puppetlabs.com/issues/7316
[3] https://github.com/puppetlabs/puppet/commit/4f99f25cd