### PR TITLE
Fix failure_message for and_returns(false)

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -1,6 +1,9 @@
 module RSpec::Puppet
   module FunctionMatchers
     class Run
+
+      @@expects_return = false
+
       def matches?(func_obj)
         @func_obj = func_obj
         if @params
@@ -28,7 +31,7 @@ module RSpec::Puppet
           end
           result
         else
-          unless @expected_return.nil?
+          if @@expects_return
             @actual_return = @func.call
             case @expected_return
             when Regexp
@@ -53,6 +56,7 @@ module RSpec::Puppet
       end
 
       def and_return(value)
+        @@expects_return = true
         @expected_return = value
         if value.is_a? Regexp
           @desc = "match #{value.inspect}"
@@ -106,7 +110,7 @@ module RSpec::Puppet
         message = "expected #{func_name}(#{func_params}) to "
         message << "not " if type == :should_not
 
-        if @expected_return
+        if @@expects_return
           message << "have returned #{@expected_return.inspect}"
           if type == :should
             message << " instead of #{@actual_return.inspect}"

--- a/spec/unit/matchers/run_spec.rb
+++ b/spec/unit/matchers/run_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+def my_bool_func(boolean)
+  return boolean
+end
+
+
+describe RSpec::Puppet::FunctionMatchers::Run do
+  describe 'and_return()' do
+    context 'with_params(true)' do
+      subject do
+        described_class.new()
+          .with_params(true)
+          .and_return(false)
+      end
+
+      it 'failure message is: have returned x instead of y' do
+        subject.matches?(self.method(:my_bool_func))
+        expect(subject.failure_message).to eq('expected my_bool_func(true) to have returned false instead of [true]')
+      end
+    end
+
+    context 'with_params(false)' do
+      subject do
+        described_class.new()
+          .with_params(false)
+          .and_return(true)
+      end
+
+      it 'failure message is: have returned x instead of y' do
+        subject.matches?(self.method(:my_bool_func))
+        expect(subject.failure_message).to eq('expected my_bool_func(false) to have returned true instead of [false]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using a test like:

 should run.with_params().and_return(false)

The matcher consider that no value is expected in return and yields a
generic failure message:

  expected my_func to have run successfully

Since we expected 'false' we should get:

  expected my_func to have returned false instead of true

Instead of checking the value directly, track whether one is expected.
Done using a dedicated class variable.

Add basic test for RSpec::Puppet::FunctionMatchers::Run