### PR TITLE
Revert "Clean up include_class deprecation notice"

### DIFF
--- a/lib/rspec-puppet/matchers/include_class.rb
+++ b/lib/rspec-puppet/matchers/include_class.rb
@@ -4,7 +4,7 @@ module RSpec::Puppet
 
     matcher :include_class do |expected_class|
       match do |catalogue|
-        RSpec.deprecate(:include_class, :contain_class)
+        RSpec.deprecate(:include_class, :replacement => :contain_class)
         catalogue.call.classes.include?(expected_class)
       end
 

--- a/spec/classes/test_classes_used_spec.rb
+++ b/spec/classes/test_classes_used_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'test::classes_used' do
   it {
-    expect(RSpec).to receive(:deprecate).with(:include_class, :contain_class)
+    expect(RSpec).to receive(:deprecate).with(:include_class, {replacement: :contain_class})
     should include_class('test::bare_class')
   }
   it {
-    expect(RSpec).to receive(:deprecate).with(:include_class, :contain_class)
+    expect(RSpec).to receive(:deprecate).with(:include_class, {replacement: :contain_class})
     should include_class('test::parameterised_class')
   }
 

--- a/spec/classes/test_classes_used_spec.rb
+++ b/spec/classes/test_classes_used_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'test::classes_used' do
   it {
-    expect(RSpec).to receive(:deprecate).with(:include_class, {replacement: :contain_class})
+    expect(RSpec).to receive(:deprecate).with(:include_class, {:replacement => :contain_class})
     should include_class('test::bare_class')
   }
   it {
-    expect(RSpec).to receive(:deprecate).with(:include_class, {replacement: :contain_class})
+    expect(RSpec).to receive(:deprecate).with(:include_class, {:replacement => :contain_class})
     should include_class('test::parameterised_class')
   }
 


### PR DESCRIPTION
If the deprecated `include_class` is used with rspec-2.99, #245 occurs.
#### Commit message of the fix
This reverts commit 8d951da86be5e61e17fec4491cb2990b8efb590b.

The RSpec-core commit c07c4cf9b47b9f58b222b77ca13daea11b3d7585
(included in 2.99.0) has changed the deprecation api:
```
    - def deprecate(deprecated, replacement_or_hash={}, ignore_version=nil)
    - data = Hash === replacement_or_hash
                        ? replacement_or_hash
                        : { :replacement => replacement_or_hash }
    + def deprecate(deprecated, data = {})
```
The commit that has been reverted changed the second parameter from
    `replacement: foo`
to
    `foo`
which is incompatible with the new form, so it has to be reverted.

Now it works with 2.X again.

Conflicts:
    lib/rspec-puppet/matchers/include_class.rb
        context conflict

The tests have also been adjusted accordingly