### PR TITLE
Filter fixtures from coverage

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -5,7 +5,8 @@ module RSpec::Puppet
 
     class << self
       extend Forwardable
-      def_delegators :instance, :add, :cover!, :report!, :filters
+      def_delegators(:instance, :add, :cover!, :report!,
+                     :filters, :add_filter, :add_from_catalog)
     end
 
     include Singleton
@@ -18,6 +19,34 @@ module RSpec::Puppet
     def add(resource)
       if !exists?(resource) && !filtered?(resource)
         @collection[resource.to_s] = ResourceWrapper.new(resource)
+      end
+    end
+
+    def add_filter(type, title)
+      @filters << "#{type.capitalize}[#{title.capitalize}]"
+    end
+
+    # add all resources from catalog declared in module test_module
+    def add_from_catalog(catalog, test_module)
+      catalog.to_a.each do |resource|
+        # check filters
+        next if @filters.include?(resource.to_s)
+        if resource.type == 'Class'
+          # if the resource is a class, make sure the class belongs to
+          # module test_module
+          module_name = resource.title.split('::').first.downcase
+          next if module_name != test_module
+        elsif resource.file
+          # otherwise, the source file should be available, so make
+          # sure the manifest declaring the resource is in
+          # test_module's directory tree or the site manifest(s)
+          paths = Puppet[:modulepath].split(File::PATH_SEPARATOR).map do |dir|
+            (Pathname.new(dir) + test_module + 'manifests').to_s
+          end
+          paths << Puppet[:manifest]
+          next unless paths.any? { |path| resource.file.include?(path) }
+        end
+        add(resource)
       end
     end
 

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -20,7 +20,7 @@ module RSpec::Puppet
 
       catalogue = build_catalog(node_name, facts_hash(node_name), code)
 
-      test_module = self.class.top_level_description.downcase.split('::').first
+      test_module = class_name.split('::').first
       RSpec::Puppet::Coverage.add_filter(type.to_s, self.class.description)
       RSpec::Puppet::Coverage.add_from_catalog(catalogue, test_module)
 
@@ -29,13 +29,11 @@ module RSpec::Puppet
     end
 
     def import_str
-      klass_name = self.class.top_level_description.downcase
-
       if File.exists?(File.join(Puppet[:modulepath], 'manifests', 'init.pp'))
         path_to_manifest = File.join([
           Puppet[:modulepath],
           'manifests',
-          klass_name.split('::')[1..-1]
+          class_name.split('::')[1..-1]
         ].flatten)
         import_str = [
           "import '#{Puppet[:modulepath]}/manifests/init.pp'",
@@ -52,19 +50,17 @@ module RSpec::Puppet
     end
 
     def test_manifest(type)
-      klass_name = self.class.top_level_description.downcase
-
       if type == :class
         if !self.respond_to?(:params) || params == {}
-          "include #{klass_name}"
+          "include #{class_name}"
         else
-          "class { '#{klass_name}': #{param_str} }"
+          "class { '#{class_name}': #{param_str} }"
         end
       elsif type == :define
         if self.respond_to? :params
-          "#{klass_name} { '#{title}': #{param_str} }"
+          "#{class_name} { '#{title}': #{param_str} }"
         else
-          "#{klass_name} { '#{title}': }"
+          "#{class_name} { '#{title}': }"
         end
       elsif type == :host
         ""
@@ -76,10 +72,13 @@ module RSpec::Puppet
       if [:class, :define, :function].include? type
         Puppet[:certname]
       else
-        self.class.top_level_description.downcase
+        class_name
       end
     end
 
+    def class_name
+      self.class.top_level_description.downcase
+    end
 
     def pre_cond
       if self.respond_to?(:pre_condition) && !pre_condition.nil?

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -20,11 +20,9 @@ module RSpec::Puppet
 
       catalogue = build_catalog(node_name, facts_hash(node_name), code)
 
-      RSpec::Puppet::Coverage.filters << "#{type.to_s.capitalize}[#{self.class.description.capitalize}]"
-
-      catalogue.to_a.each do |resource|
-        RSpec::Puppet::Coverage.add(resource)
-      end
+      test_module = self.class.top_level_description.downcase.split('::').first
+      RSpec::Puppet::Coverage.add_filter(type.to_s, self.class.description)
+      RSpec::Puppet::Coverage.add_from_catalog(catalogue, test_module)
 
       FileUtils.rm_rf(vardir) if File.directory?(vardir)
       catalogue


### PR DESCRIPTION
This is a fix for issue #157.  This changes the code coverage report to include only the resources that are declared in the module being tested and the site manifest(s).  Previously, all resources in the catalog generated for a particular test run were added to the coverage list which meant that any test fixtures were also added to the coverage report and were reported as untouched.