### PR TITLE
Improve dependency detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,49 @@ When testing custom types, the `be_valid_type` matcher provides a range of expec
 * `with_features(<feature_list>)`: check that the specified features are available
 * `with_set_attributes(<param_value_hash>)`: check that the specified attributes are set 
 
+#### Recursive dependencies
+
+The relationship matchers are recursive in two directions:
+
+* vertical recursion, which checks for dependencies with parents of the resource
+ (i.e. the resource is contained, directly or not, in the class involved in the relationship).
+ E.g. where `Package['foo']` comes before `File['/foo']`:
+
+```puppet
+class { 'foo::install': } ->
+class { 'foo::config': }
+
+class foo::install {
+  package { 'foo': }
+}
+
+class foo::config {
+  file { '/foo': }
+}
+```
+
+
+* horizontal recursion, which follows indirect dependencies (dependencies of dependencies).
+ E.g. where `Yumrepo['foo']` comes before `File['/foo']`:
+
+```puppet
+class { 'foo::repo': } ->
+class { 'foo::install': } ->
+class { 'foo::config': }
+
+class foo::repo {
+  yumrepo { 'foo': }
+}
+
+class foo::install {
+  package { 'foo': }
+}
+
+class foo::config {
+  file { '/foo': }
+}
+```
+
 ### Writing tests
 
 #### Basic test structure

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ class foo::config {
 }
 ```
 
+#### Autorequires
+
+Autorequires are considered in dependency checks.
+
+
 ### Writing tests
 
 #### Basic test structure

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -239,14 +239,20 @@ module RSpec::Puppet
         ref.is_a?(Puppet::Resource) ? ref : @catalogue.resource(ref)
       end
 
+      def canonicalize_resource(resource)
+        resource_from_ref(resource_ref(resource))
+      end
+
+      def canonicalize_resource_ref(ref)
+        resource_ref(resource_from_ref(ref))
+      end
+
       def relationship_refs(resource, type)
-        # Canonize resource
-        resource = resource_from_ref(resource.to_ref)
+        resource = canonicalize_resource(resource)
         results = []
         Array[resource[type]].flatten.compact.each do |r|
-          res = resource_from_ref(r)
-          results << resource_ref(res)
-          results << relationship_refs(res, type)
+          results << canonicalize_resource_ref(r)
+          results << relationship_refs(r, type)
         end
 
         # Add autorequires if any
@@ -255,7 +261,7 @@ module RSpec::Puppet
             Array(resource.to_ral.instance_eval(&b)).each do |dep|
               res = "#{t.to_s.capitalize}[#{dep}]"
               results << res
-              results << relationship_refs(resource_from_ref(res), type)
+              results << relationship_refs(res, type)
             end
           end
         end

--- a/spec/classes/relationship__before_spec.rb
+++ b/spec/classes/relationship__before_spec.rb
@@ -17,4 +17,12 @@ describe 'relationships::before' do
 
   it { should contain_notify('pre').that_comes_before(['Notify[post]']) }
   it { should contain_notify('post').that_requires(['Notify[pre]']) }
+
+  it { should contain_file('/tmp/foo').that_comes_before(['File[/tmp/foo/bar]']) }
+  it { should contain_file('/tmp/foo/bar').that_requires(['File[/tmp/foo]']) }
+
+  it { should contain_notify('bazz').that_comes_before(['File[/tmp/foo/bar]']) }
+  it { should contain_notify('qux').that_requires(['File[/tmp/foo]']) }
+  it { should contain_notify('bazz').that_comes_before(['Notify[qux]']) }
+  it { should contain_notify('qux').that_requires(['Notify[bazz]']) }
 end

--- a/spec/classes/relationship__before_spec.rb
+++ b/spec/classes/relationship__before_spec.rb
@@ -14,4 +14,7 @@ describe 'relationships::before' do
 
   it { should contain_notify('bar').that_requires(['Notify[foo]']) }
   it { should contain_notify('baz').that_requires(['Notify[foo]','Notify[bar]']) }
+
+  it { should contain_notify('pre').that_comes_before(['Notify[post]']) }
+  it { should contain_notify('post').that_requires(['Notify[pre]']) }
 end

--- a/spec/classes/relationship__notify_spec.rb
+++ b/spec/classes/relationship__notify_spec.rb
@@ -14,4 +14,7 @@ describe 'relationships::notify' do
 
   it { should contain_notify('gronk').that_subscribes_to(['Notify[baz]']) }
   it { should contain_notify('bar').that_subscribes_to(['Notify[baz]','Notify[foo]']) }
+
+  it { should contain_notify('pre').that_notifies(['Notify[post]']) }
+  it { should contain_notify('post').that_subscribes_to(['Notify[pre]']) }
 end

--- a/spec/fixtures/modules/relationships/manifests/before.pp
+++ b/spec/fixtures/modules/relationships/manifests/before.pp
@@ -10,11 +10,16 @@ class relationships::before {
   Notify['baz'] <- Notify['bar']
 
   class { '::relationship::before::pre': } ->
+  class { '::relationship::before::middle': } ->
   class { '::relationship::before::post': }
 }
 
 class relationship::before::pre {
   notify { 'pre': }
+}
+
+class relationship::before::middle {
+  notify { 'middle': }
 }
 
 class relationship::before::post {

--- a/spec/fixtures/modules/relationships/manifests/before.pp
+++ b/spec/fixtures/modules/relationships/manifests/before.pp
@@ -6,6 +6,12 @@ class relationships::before {
   notify { 'bar': }
   notify { 'baz': }
 
+  file { '/tmp/foo': ensure => directory }
+  file { '/tmp/foo/bar': ensure => file }
+
+  notify { 'bazz': before => File['/tmp/foo'] }
+  notify { 'qux': require => File['/tmp/foo/bar'] }
+
   Notify['foo'] -> Notify['baz']
   Notify['baz'] <- Notify['bar']
 

--- a/spec/fixtures/modules/relationships/manifests/before.pp
+++ b/spec/fixtures/modules/relationships/manifests/before.pp
@@ -8,4 +8,15 @@ class relationships::before {
 
   Notify['foo'] -> Notify['baz']
   Notify['baz'] <- Notify['bar']
+
+  class { '::relationship::before::pre': } ->
+  class { '::relationship::before::post': }
+}
+
+class relationship::before::pre {
+  notify { 'pre': }
+}
+
+class relationship::before::post {
+  notify { 'post': }
 }

--- a/spec/fixtures/modules/relationships/manifests/notify.pp
+++ b/spec/fixtures/modules/relationships/manifests/notify.pp
@@ -13,11 +13,16 @@ class relationships::notify {
   Notify['gronk'] <~ Notify['baz']
 
   class { '::relationship::notify::pre': } ~>
+  class { '::relationship::notify::middle': } ~>
   class { '::relationship::notify::post': }
 }
 
 class relationship::notify::pre {
   notify { 'pre': }
+}
+
+class relationship::notify::middle {
+  notify { 'middle': }
 }
 
 class relationship::notify::post {

--- a/spec/fixtures/modules/relationships/manifests/notify.pp
+++ b/spec/fixtures/modules/relationships/manifests/notify.pp
@@ -11,4 +11,15 @@ class relationships::notify {
   notify { 'gronk': }
 
   Notify['gronk'] <~ Notify['baz']
+
+  class { '::relationship::notify::pre': } ~>
+  class { '::relationship::notify::post': }
+}
+
+class relationship::notify::pre {
+  notify { 'pre': }
+}
+
+class relationship::notify::post {
+  notify { 'post': }
 }


### PR DESCRIPTION
When refactoring (and potentially in other cases), it is useful to express resource dependencies that are not direct.

This PR adds two levels of recursion to dependency detection:

* test dependencies on all levels, which checks for dependencies with parents of the resource (i.e. the resource is contained, directly or not, in the class involved in the relationship). You can think of this as a vertical recursion. E.g. where Package['foo'] comes before File['/foo']:

```puppet
class { 'foo::install': } ->
class { 'foo::config': }

class foo::install {
  package { 'foo': }
}

class foo::config {
  file { '/foo': }
}
```

* test dependencies recursively by following indirect dependencies (dependencies of dependencies). This is a horizontal recursion. E.g. where Yumrepo['foo'] comes before File['/foo']:

```puppet
class { 'foo::repo': } ->
class { 'foo::install': } ->
class { 'foo::config': }

class foo::repo {
  yumrepo { 'foo': }
}

class foo::install {
  package { 'foo': }
}

class foo::config {
  file { '/foo': }
}
```


In addition to this, this series also adds support for autorequires detection. I put this there because it goes tightly with the recursive code.


