### PR TITLE
Adding stuff for puppet 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,16 @@ env:
   - PUPPET_VERSION=3.3.2
   - PUPPET_VERSION=3.4.3
   - PUPPET_VERSION=3.5.1
+  - PUPPET_VERSION=4.0.0
   - RSPEC_VERSION=2.14
 matrix:
   exclude:
+    - rvm: 1.8.7
+      env: PUPPET_VERSION=4.0.0
     - rvm: 1.9.2
       env: PUPPET_VERSION=2.6.18
+    - rvm: 1.9.2
+      env: PUPPET_VERSION=4.0.0
     - rvm: 1.9.3
       env: PUPPET_VERSION=2.6.18
     - rvm: 2.0.0

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -14,6 +14,7 @@ rescue LoadError
 end
 
 RSpec.configure do |c|
+  c.add_setting :environmentpath, :default => '/etc/puppetlabs/code/environments'
   c.add_setting :module_path, :default => '/etc/puppet/modules'
   c.add_setting :manifest_dir, :default => nil
   c.add_setting :manifest, :default => nil

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -11,6 +11,13 @@ module RSpec::Puppet
 
       node_name = nodename(:function)
 
+      if Puppet.version.to_f >= 4.0
+        env = Puppet::Node::Environment.create(:testing, [File.join(Puppet[:environmentpath],'fixtures','modules')], File.join(Puppet[:environmentpath],'fixtures','manifests'))
+        loader = Puppet::Pops::Loaders.new(env)
+        func = loader.private_environment_loader.load(:function,function_name)
+        return func if func
+      end
+
       function_scope = scope(compiler, node_name)
 
       # Return the method instance for the function.  This can be used with

--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -92,7 +92,7 @@ module RSpec::Puppet
         end
 
         expected.keys.all? do |key|
-          check(expected[key], actual[key.to_s])
+          check(expected[key], actual[key])
         end
       end
 

--- a/spec/classes/boolean_regexp_spec.rb
+++ b/spec/classes/boolean_regexp_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'boolean' do
+describe 'boolean_test' do
   let(:title) { 'bool.testing' }
   let(:params) { { :bool => false } }
   let(:message_re) { /bool is false/ }

--- a/spec/classes/boolean_spec.rb
+++ b/spec/classes/boolean_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::PUPPETVERSION !~ /0\.2/
-  describe 'boolean' do
+  describe 'boolean_test' do
     let(:title) { 'bool.testing' }
     let(:params) { { :bool => false } }
   

--- a/spec/classes/hash_spec.rb
+++ b/spec/classes/hash_spec.rb
@@ -18,11 +18,20 @@ describe 'structured_data' do
       { 'data'  => {1 => 'uno', 2 => 'dos'}}
     end
 
-    it {
-      should contain_structured_data__def('thing').with(
-        { 'data'  => {1 => 'uno', 2 => 'dos'}}
-      )
-    }
+    context "puppet less than 4", :unless => Puppet.version.to_f >= 4.0 do
+      it {
+        should contain_structured_data__def('thing').with(
+          { 'data'  => {"1" => 'uno', "2" => 'dos'}}
+        )
+      }
+    end
+    context "puppet 4 or greater", :if => Puppet.version.to_f >= 4.0 do
+      it {
+        should contain_structured_data__def('thing').with(
+          { 'data'  => {1 => 'uno', 2 => 'dos'}}
+        )
+      }
+    end
   end
 
   describe 'with integers as values' do

--- a/spec/classes/sysctl_common_spec.rb
+++ b/spec/classes/sysctl_common_spec.rb
@@ -49,7 +49,13 @@ describe 'sysctl::common' do
     .with_test_param("yes") }
   it { should have_class_count(1) }
   it { should have_exec_resource_count(1) }
-  it { should have_resource_count(2) }
+  it {
+    if Puppet.version.to_f >= 4.0
+      should have_resource_count(1)
+    else
+      should have_resource_count(2)
+    end
+  }
 end
 
 describe 'sysctl::common' do

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -46,6 +46,6 @@ node 'facts.acme.com' {
     path => $domain
   }
   file { 'clientcert':
-    path => $clientcert
+    path => "cert ${clientcert}"
   }
 }

--- a/spec/fixtures/modules/boolean_test/manifests/init.pp
+++ b/spec/fixtures/modules/boolean_test/manifests/init.pp
@@ -1,9 +1,9 @@
-class boolean($bool) {
+class boolean_test($bool) {
   $real_bool = $bool ? {
     true => false,
     false => true,
   }
-  
+
   if ($real_bool) {
     notify {"bool testing":
       message => "This will print when \$bool is false."

--- a/spec/fixtures/modules/structured_data/manifests/def.pp
+++ b/spec/fixtures/modules/structured_data/manifests/def.pp
@@ -1,5 +1,5 @@
 define structured_data::def($data = {}) {
-  $template = inline_template('<%= data.inspect %>')
+  $template = inline_template('<%= @data.inspect %>')
 
   notify { "$template": }
 }

--- a/spec/fixtures/modules/sysctl/manifests/init.pp
+++ b/spec/fixtures/modules/sysctl/manifests/init.pp
@@ -17,7 +17,7 @@ define sysctl($value) {
   }
 }
 
-class boolean($bool) {
+class boolean_test($bool) {
   $real_bool = $bool ? {
     true => false,
     false => true,

--- a/spec/fixtures/modules/test/lib/puppet/functions/test_function.rb
+++ b/spec/fixtures/modules/test/lib/puppet/functions/test_function.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:test_function) do
+  def test_function(value)
+    "value is #{value}"
+  end
+end

--- a/spec/functions/split_spec.rb
+++ b/spec/functions/split_spec.rb
@@ -10,21 +10,15 @@ describe 'split' do
     expected_error = Puppet::ParseError
   end
 
+  if Puppet.version.to_f >= 4.0
+    expected_error_message = /mis-matched arguments/
+  else
+    expected_error_message = /number of arguments/
+  end
+
   it { should run.with_params('foo').and_raise_error(expected_error) }
 
-  it { should run.with_params('foo').and_raise_error(expected_error, /number of arguments/) }
+  it { should run.with_params('foo').and_raise_error(expected_error, expected_error_message) }
 
-  it { should run.with_params('foo').and_raise_error(/number of arguments/) }
-
-  it 'should fail with one argument - match exception type' do
-    expect { subject.call(['foo']) }.to raise_error(expected_error)
-  end
-
-  it 'should fail with one argument - match exception type and message' do
-    expect { subject.call(['foo']) }.to raise_error(expected_error, /number of arguments/)
-  end
-
-  it 'should fail with one argument - match exception message' do
-    expect { subject.call(['foo']) }.to raise_error(/number of arguments/)
-  end
+  it { should run.with_params('foo').and_raise_error(expected_error_message) }
 end

--- a/spec/functions/test_function_spec.rb
+++ b/spec/functions/test_function_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe 'test_function', :if => Puppet.version.to_f >= 4.0 do
+  # Verify that we can load functions from modules
+  it { should run.with_params('foo').and_return(/value is foo/) }
+end

--- a/spec/hosts/facts_spec.rb
+++ b/spec/hosts/facts_spec.rb
@@ -6,5 +6,5 @@ describe 'facts.acme.com' do
   it { should contain_file('fqdn').with_path('facts.acme.com') }
   it { should contain_file('hostname').with_path('facts') }
   it { should contain_file('domain').with_path('acme.com') }
-  it { should contain_file('clientcert').with_path('facts.acme.com') }
+  it { should contain_file('clientcert').with_path('cert facts.acme.com') }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,5 @@ require 'rspec-puppet'
 RSpec.configure do |c|
   c.module_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'modules')
   c.manifest_dir = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests')
+  c.environmentpath = spec_path = File.expand_path(File.join(Dir.pwd, 'spec'))
 end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -9,11 +9,11 @@ describe RSpec::Puppet::Support do
   end
 
   describe '#setup_puppet' do
-    it 'sets Puppet[:parser] to "current" by default' do
+    it 'sets Puppet[:parser] to "current" by default', :unless => Puppet.version.to_f >= 4.0 do
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("current")
     end
-    it 'reads the :parser setting' do
+    it 'reads the :parser setting', :unless => Puppet.version.to_f >= 4.0 do
       allow(subject).to receive(:parser).and_return("future")
       subject.setup_puppet
       expect(Puppet[:parser]).to eq("future")


### PR DESCRIPTION
Puppet 4 uses environmentpath instead of modulepath and manifest
settings. We can use an environment of 'fixtures' to access the
spec/fixtures/{manifests,modules} directories for compiling a catalog.