### PR TITLE
Decouple the message from what the subject function does to it's argumen...

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -49,6 +49,9 @@ module RSpec::Puppet
 
       def with_params(*params)
         @params = params
+        # stringify immediatly to protect us from the params being changed by
+        # the subject, e.g. with params.shift
+        @func_args = @params.inspect[1..-2]
         self
       end
 
@@ -99,7 +102,7 @@ module RSpec::Puppet
       end
 
       def func_params
-        @func_args ||= @params.inspect[1..-2]
+        @func_args
       end
 
       def failure_message_generic(type, func_obj)

--- a/spec/fixtures/modules/functions/lib/puppet/parser/functions/nasty.rb
+++ b/spec/fixtures/modules/functions/lib/puppet/parser/functions/nasty.rb
@@ -1,0 +1,3 @@
+Puppet::Parser::Functions.newfunction(:nasty, :type => :rvalue) do |arguments|
+  arguments.shift
+end

--- a/spec/functions/nasty_spec.rb
+++ b/spec/functions/nasty_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'nasty' do
+  describe 'the underlying Run matcher' do
+    it 'should not have its description manipulated by running the function' do
+      run_matcher = run.with_params('foo', 'bar').and_return('foo')
+      should run_matcher
+      expect(run_matcher.description).to eq('run nasty("foo", "bar") and return "foo"')
+    end
+  end
+end


### PR DESCRIPTION
...ts

Before that, a subject that would e.g. shift the argument array would cause the
final message to be modified. With this change, the @func_args are initialised
immediately and not accessible anymore to modificatoin from the subject.