### PR TITLE
Unify environment setting and allow customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,15 @@ you can specify this as follows
 let(:node) { 'testhost.example.com' }
 ```
 
+#### Specifying the environment name
+
+If the manifest you're testing expects to evaluate the environment name,
+you can specify this as follows
+
+```ruby
+let(:environment) { 'production' }
+```
+
 #### Specifying the facts that should be available to your manifest
 
 By default, the test environment contains no facts for your manifest to use.

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -12,7 +12,7 @@ module RSpec::Puppet
       node_name = nodename(:function)
 
       if Puppet.version.to_f >= 4.0
-        env = Puppet::Node::Environment.create(:testing, [File.join(Puppet[:environmentpath],'fixtures','modules')], File.join(Puppet[:environmentpath],'fixtures','manifests'))
+        env = Puppet::Node::Environment.create(environment, [File.join(Puppet[:environmentpath],'fixtures','modules')], File.join(Puppet[:environmentpath],'fixtures','manifests'))
         loader = Puppet::Pops::Loaders.new(env)
         func = loader.private_environment_loader.load(:function,function_name)
         return func if func

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -7,6 +7,10 @@ module RSpec::Puppet
       lambda { catalogue }
     end
 
+    def environment
+      'rp_env'
+    end
+
     def load_catalogue(type)
       vardir = setup_puppet
 
@@ -95,7 +99,7 @@ module RSpec::Puppet
     def facts_hash(node)
       facts_val = {
         'clientversion' => Puppet::PUPPETVERSION,
-        'environment'   => 'production',
+        'environment'   => environment,
         'hostname'      => node.split('.').first,
         'fqdn'          => node,
         'domain'        => node.split('.', 2).last,
@@ -168,7 +172,7 @@ module RSpec::Puppet
         Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
       elsif Puppet.version.to_f >= 4.0
         env = Puppet::Node::Environment.create(
-          node_obj.environment.name,
+          environment,
           [File.join(Puppet[:environmentpath],'fixtures','modules')],
           File.join(Puppet[:environmentpath],'fixtures','manifests'))
         loader = Puppet::Environments::Static.new(env)
@@ -219,11 +223,11 @@ module RSpec::Puppet
     def build_node(name, opts = {})
       if Puppet.version.to_f >= 4.0
         node_environment = Puppet::Node::Environment.create(
-          'test',
+          environment,
           [File.join(Puppet[:environmentpath],'fixtures','modules')],
           File.join(Puppet[:environmentpath],'fixtures','manifests'))
       else
-        node_environment = Puppet::Node::Environment.new('test')
+        node_environment = Puppet::Node::Environment.new(environment)
       end
       opts.merge!({:environment => node_environment})
       Puppet::Node.new(name, opts)

--- a/spec/hosts/environment_spec.rb
+++ b/spec/hosts/environment_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'facts.acme.com' do
+  context 'without an explicit environment setting' do
+    it { should contain_file('environment').with_path('rp_env') }
+  end
+  context 'when specifying an explicit environment' do
+    let(:environment) { 'test_env' }
+    it { should contain_file('environment').with_path('test_env') }
+  end
+end

--- a/spec/hosts/facts_spec.rb
+++ b/spec/hosts/facts_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'facts.acme.com' do
-  it { should contain_file('environment').with_path('production') }
+  it { should contain_file('environment').with_path('rp_env') }
   it { should contain_file('clientversion').with_path(Puppet::PUPPETVERSION) }
   it { should contain_file('fqdn').with_path('facts.acme.com') }
   it { should contain_file('hostname').with_path('facts') }


### PR DESCRIPTION
Before this commit, the environment was test, testing, or production
depending on which kind of test it was. This commit unifies it to be a
unique string that should be useful for validating tests that require
environment to be set, and documents how to set it.