### PR TITLE
Don't match compile.and_raise_error on success

### DIFF
--- a/lib/rspec-puppet/matchers/compile.rb
+++ b/lib/rspec-puppet/matchers/compile.rb
@@ -27,7 +27,7 @@ module RSpec::Puppet
           elsif @check_deps == true && missing_dependencies?
             false
           else
-            true
+            @expected_error.nil?
           end
         rescue Puppet::Error => e
           @error_msg = e.message
@@ -58,13 +58,24 @@ module RSpec::Puppet
           unless @error_msg.empty?
             "error during compilation: #{@error_msg}"
           else
-            "expected that the catalogue would include #{@failed_resource}"
+            case @expected_error
+            when nil
+              "expected that the catalogue would include #{@failed_resource}"
+            when Regexp
+              "expected that the catalogue would fail to compile and raise an error matching #{@expected_error.inspect}"
+            else
+              "expected that the catalogue would fail to compile and raise the error #{@expected_error.inspect}"
+            end
           end
         end
       end
 
       def failure_message_when_negated
-        "expected that the catalogue would not compile but it does"
+        if @expected_error.nil?
+          "expected that the catalogue would not compile but it does"
+        else
+          "expected that the catalogue would compile but it does not"
+        end
       end
 
       private

--- a/spec/classes/cycle_good_spec.rb
+++ b/spec/classes/cycle_good_spec.rb
@@ -2,4 +2,5 @@ require 'spec_helper'
 
 describe 'cycle::good' do
   it { should compile }
+  it { should_not compile.and_raise_error(//) }
 end


### PR DESCRIPTION
Make the behavior of `compile.and_raise_error` match that of
`run.and_raise_error` and `should raise_error`: if compilation succeeds
and does not in fact raise an error, this should be considered a unit
test failure that is reported.

It would previously succeed even if no error was raised.

Fixes #276.