### PR TITLE
Allow undef parameter passing with nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ let(:title) { 'foo' }
 let(:params) { {:ensure => 'present', ...} }
 ```
 
+##### Passing Puppet's `undef` as a parameter value
+
+```ruby
+let(:params) { {:user => nil, ...} }
+```
+
 #### Specifying the FQDN of the test node
 
 If the manifest you're testing expects to run on host with a particular name,

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -116,8 +116,10 @@ module RSpec::Puppet
 
     def param_str
       params.keys.map do |r|
-        param_val = escape_special_chars(params[r].inspect)
-        "#{r.to_s} => #{param_val}"
+        param_val = params[r]
+        is_undef = param_val.nil?
+        param_val_str = escape_special_chars(is_undef ? 'undef' : param_val.inspect)
+        "#{r.to_s} => #{param_val_str}"
       end.join(', ')
     end
 

--- a/spec/classes/undef_spec.rb
+++ b/spec/classes/undef_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'undef' do
+  it { should compile.with_all_deps }
+
+  shared_examples 'exec echo' do
+    it { should contain_exec('/bin/echo foo').with_user(nil) }
+  end
+
+  context 'with user => nil' do
+    let(:params) { { :user => nil } }
+    include_examples 'exec echo'
+  end
+
+  context 'with params unset' do
+    include_examples 'exec echo'
+  end
+end

--- a/spec/defines/undef_def_spec.rb
+++ b/spec/defines/undef_def_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'undef::def' do
+  let(:title) { '/bin/echo foo' }
+
+  it { should compile.with_all_deps }
+
+  shared_examples 'exec echo' do
+    it { should contain_exec('/bin/echo foo').with_user(nil) }
+  end
+
+  context 'with user => nil' do
+    let(:params) { { :user => nil } }
+    include_examples 'exec echo'
+  end
+
+  context 'with params unset' do
+    include_examples 'exec echo'
+  end
+end

--- a/spec/fixtures/modules/undef/manifests/def.pp
+++ b/spec/fixtures/modules/undef/manifests/def.pp
@@ -1,0 +1,5 @@
+define undef::def($user = undef) {
+  exec { '/bin/echo foo' :
+    user  => $user,
+  }
+}

--- a/spec/fixtures/modules/undef/manifests/init.pp
+++ b/spec/fixtures/modules/undef/manifests/init.pp
@@ -1,0 +1,5 @@
+class undef($user = undef) {
+  exec { '/bin/echo foo':
+    user => $user,
+  }
+}


### PR DESCRIPTION
Now, when `nil` is used as a param value, its `inspect` method is not
called to construct the Puppet parameter value. Instead, the unquoted
string `'undef'` is used in the generated resource declaration. So now
`let(:params) { { :foo => nil } }` leads to the desired resource
declaration `class { 'test': foo => undef }`.

Puppet `undef` is nearly equivalent to Ruby `nil`, and there is no `nil`
in Puppet, so it makes sense to do this translation.

Before this change, it was impossible to pass `undef` as a parameter.
Using `nil`, `:undef`, or `'undef'` all failed for various reasons.

Credit to the discussion at [1] for identifying the issue and proposing
an alternate solution.

Fixes #279.

[1] https://groups.google.com/forum/#!topic/puppet-users/6nL2eROH8is