### PR TITLE
FunctionMatchers::Run: make return value optional

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -64,10 +64,12 @@ module RSpec::Puppet
         self
       end
 
-      def and_return(value)
+      def and_return(value=nil)
         @expected_return = value
         if value.is_a? Regexp
           @desc = "match #{value.inspect}"
+        elsif value.nil?
+          @desc = "return nothing"
         else
           @desc = "return #{value.inspect}"
         end


### PR DESCRIPTION
I'm not sure whether that's a good solution, but without this, functions like `validate_...` have many descriptions with a dangling 'and'. `@desc` could be initialised to `'return nothing'`by default to avoid having to specify `.and_return` in all the specs.