### PR TITLE
Several bug fixes and specs for Run matcher

### DIFF
--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -123,15 +123,30 @@ module RSpec::Puppet
         @func_args
       end
 
+      def failure_message_actual(type)
+        if type != :should
+          ''
+        elsif @actual_error
+          if @has_expected_return
+            " instead of raising #{@actual_error.class.inspect}(#{@actual_error})"
+          else
+            " instead of #{@actual_error.class.inspect}(#{@actual_error})"
+          end
+        else # function has returned
+          if @has_expected_error
+            " instead of returning #{@actual_return.inspect}"
+          else
+            " instead of #{@actual_return.inspect}"
+          end
+        end
+      end
+
       def failure_message_generic(type, func_obj)
         message = "expected #{func_name}(#{func_params}) to "
         message << "not " if type == :should_not
 
         if @has_expected_return
           message << "have returned #{@expected_return.inspect}"
-          if type == :should
-            message << " instead of #{@actual_return.inspect}"
-          end
         else
           if @has_expected_error
             message << "have raised #{@expected_error.inspect}"
@@ -141,18 +156,8 @@ module RSpec::Puppet
           else
             message << "have run successfully"
           end
-          if type == :should
-            if @actual_error
-              message << " instead of raising #{@actual_error.class.inspect}"
-              if @expected_error_message
-                message << "(#{@actual_error})"
-              end
-            elsif @has_returned
-              message << " instead of returning #{@actual_return.class.inspect}"
-            end
-          end
         end
-        message
+        message << failure_message_actual(type)
       end
     end
   end

--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -107,7 +107,11 @@ module RSpec::Puppet
       end
 
       def description
-        "run #{func_name}(#{func_params}) and #{@desc}"
+        if @desc
+          "run #{func_name}(#{func_params}) and #{@desc}"
+        else
+          "run #{func_name}(#{func_params}) without error"
+        end
       end
 
       private

--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -35,23 +35,27 @@ module RSpec::Puppet
               end
             end
           end
-          result
+          return result
         else
-          unless @expected_return.nil?
-            @actual_return = @func.call
+          if @has_expected_return
+            begin
+              @actual_return = @func.call
+            rescue
+              return false
+            end
             case @expected_return
             when Regexp
-              @actual_return =~ @expected_return
+              return @actual_return =~ @expected_return
             else
-              @actual_return == @expected_return
+              return @actual_return == @expected_return
             end
           else
             begin
               @func.call
             rescue
-              false
+              return false
             end
-            true
+            return true
           end
         end
       end
@@ -65,6 +69,7 @@ module RSpec::Puppet
       end
 
       def and_return(value)
+        @has_expected_return = true
         @expected_return = value
         if value.is_a? Regexp
           @desc = "match #{value.inspect}"
@@ -122,7 +127,7 @@ module RSpec::Puppet
         message = "expected #{func_name}(#{func_params}) to "
         message << "not " if type == :should_not
 
-        if @expected_return
+        if @has_expected_return
           message << "have returned #{@expected_return.inspect}"
           if type == :should
             message << " instead of #{@actual_return.inspect}"

--- a/spec/unit/matchers/run_spec.rb
+++ b/spec/unit/matchers/run_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe RSpec::Puppet::FunctionMatchers::Run do
+  it 'should call the lambda with no params' do
+    received_params = nil
+    if Puppet.version.to_f >= 4.0
+      subject.matches?(lambda { |env, *params| received_params = params })
+      expect(received_params).to eq([])
+    else
+      subject.matches?(lambda { |params| received_params = params })
+      expect(received_params).to be_nil
+    end
+  end
+
+  it 'should not match a lambda that raises an error' do
+    expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be_false
+  end
+
+  [ [], [true], [false], [''], ['string'], [nil], [0], [1.1], [[]], ['one', 'two'], [{}], [{ 'key' => 'value' }], [:undef] ].each do |supplied_params|
+    context "with_params(#{supplied_params.collect { |p| p.inspect }.join(', ')})" do
+      before(:each) { subject.with_params(*supplied_params) }
+
+      it 'should call the lambda with the supplied params' do
+        received_params = nil
+        if Puppet.version.to_f >= 4.0
+          subject.matches?(lambda { |env, *params| received_params = params })
+        else
+          subject.matches?(lambda { |params| received_params = params })
+        end
+        expect(received_params).to eq(supplied_params)
+      end
+
+      it 'should not match a lambda that raises an error' do
+        expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be_false
+      end
+
+      [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |expected_return|
+        context "and_return(#{expected_return.inspect})" do
+          before(:each) { subject.and_return(expected_return) }
+
+          it 'should match a lambda that does return the requested value' do
+            expect(subject.matches?(lambda { |env, *params| expected_return })).to be_true
+          end
+
+          it 'should not match a lambda that does return a different value' do
+            expect(subject.matches?(lambda { |env, *params| !expected_return })).to be_false
+          end
+
+          it 'should not match a lambda that raises an error' do
+            expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be_false
+          end
+        end
+      end
+
+      context "and_raise_error(ArgumentError)" do
+        before(:each) { subject.and_raise_error(ArgumentError) }
+
+        it 'should match a lambda that raises ArgumentError' do
+          expect(subject.matches?(lambda { |env, *params| raise ArgumentError, 'Forced Error' })).to be_true
+        end
+
+        [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |value|
+          it "should not match a lambda that returns #{value.inspect}" do
+            expect(subject.matches?(lambda { |env, *params| value })).to be_false
+          end
+        end
+
+        it 'should not match a lambda that raises a different error' do
+          expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be_false
+        end
+      end
+
+      context "and_raise_error(ArgumentError, /message/)" do
+        before(:each) { subject.and_raise_error(ArgumentError, /message/) }
+
+        it 'should match a lambda that raises ArgumentError("with matching message")' do
+          expect(subject.matches?(lambda { |env, *params| raise ArgumentError, 'with matching message' })).to be_true
+        end
+
+        it 'should not match a lambda that raises a different ArgumentError' do
+          expect(subject.matches?(lambda { |env, *params| raise ArgumentError, 'Forced Error' })).to be_false
+        end
+
+        [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |value|
+          it "should not match a lambda that returns #{value.inspect}" do
+            expect(subject.matches?(lambda { |env, *params| value })).to be_false
+          end
+        end
+
+        it 'should not match a lambda that raises a different error' do
+          expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be_false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without the changes to run.rb, the following specs would fail:

```
rspec ./spec/unit/matchers/run_spec.rb:10 # RSpec::Puppet::FunctionMatchers::Run should not match a lambda that raises an error

rspec ./spec/unit/matchers/run_spec.rb:24 # RSpec::Puppet::FunctionMatchers::Run with_params() should not match a lambda that raises an error

rspec ./spec/unit/matchers/run_spec.rb:40 # RSpec::Puppet::FunctionMatchers::Run with_params(*anything*) and_return(*anything*) should not match a lambda that raises an error

rspec ./spec/unit/matchers/run_spec.rb:36 # RSpec::Puppet::FunctionMatchers::Run with_params(*anything*) and_return(nil) should not match a lambda that does return a different value
```