### PR TITLE
Add environmentpath setting required for puppet 4

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -117,6 +117,7 @@ fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.environmentpath = File.join(Dir.pwd, 'spec')
 end
 EOF
     safe_create_file('spec/spec_helper.rb', content)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,5 @@ require 'rspec-puppet'
 RSpec.configure do |c|
   c.module_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'modules')
   c.manifest_dir = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests')
-  c.environmentpath = spec_path = File.expand_path(File.join(Dir.pwd, 'spec'))
+  c.environmentpath = File.join(Dir.pwd, 'spec')
 end


### PR DESCRIPTION
This setting, copied from rspec-puppet's own spec_helper.rb, allows puppet 4 to find custom functions in the test fixtures (which include symlinks to the module under test).