### PR TITLE
Use the correct lexer for Puppet 4 in setup.rb

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -55,6 +55,8 @@ module RSpec::Puppet
     end
 
     def self.get_module_name_from_file(file)
+      # FIXME: see discussion at
+      # https://github.com/rodjek/rspec-puppet/issues/290
       if Puppet.version.to_f >= 4.0
         p = Puppet::Pops::Parser::Lexer2.new
       else


### PR DESCRIPTION
Without this patch applied, rspec-puppet-init errors out with
    `get_module_name_from_file': uninitialized constant Puppet::Parser::Lexer (NameError)
for Puppet 4.