### PR TITLE
Expose the scope in function example groups

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -9,16 +9,12 @@ module RSpec::Puppet
 
       vardir = setup_puppet
 
-      node_name = nodename(:function)
-
       if Puppet.version.to_f >= 4.0
         env = Puppet::Node::Environment.create(environment, [File.join(Puppet[:environmentpath],'fixtures','modules')], File.join(Puppet[:environmentpath],'fixtures','manifests'))
         loader = Puppet::Pops::Loaders.new(env)
         func = loader.private_environment_loader.load(:function,function_name)
         return func if func
       end
-
-      function_scope = scope(compiler, node_name)
 
       # Return the method instance for the function.  This can be used with
       # method.call
@@ -28,7 +24,11 @@ module RSpec::Puppet
         return nil unless Puppet::Parser::Functions.function(function_name)
       end
       FileUtils.rm_rf(vardir) if File.directory?(vardir)
-      function_scope.method("function_#{function_name}".intern)
+      scope.method("function_#{function_name}".intern)
+    end
+
+    def scope
+      @scope ||= build_scope(compiler, nodename(:function))
     end
 
     def catalogue

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -207,7 +207,7 @@ module RSpec::Puppet
       string
     end
 
-    def scope(compiler, node_name)
+    def build_scope(compiler, node_name)
       if Puppet.version =~ /^2\.[67]/
         # loadall should only be necessary prior to 3.x
         # Please note, loadall needs to happen first when creating a scope, otherwise


### PR DESCRIPTION
Some examples require access to the scope for stubbing.