### PR TITLE
Break out spec_helper and rake_task

### DIFF
--- a/lib/rspec-puppet/rake_task.rb
+++ b/lib/rspec-puppet/rake_task.rb
@@ -1,0 +1,20 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+desc "Run all RSpec code examples"
+RSpec::Core::RakeTask.new(:rspec) do |t|
+  File.exist?('spec/spec.opts') ? opts = File.read("spec/spec.opts").chomp : opts = ""
+  t.rspec_opts = opts
+end
+
+SPEC_SUITES = (Dir.entries('spec') - ['.', '..','fixtures']).select {|e| File.directory? "spec/#{e}" }
+namespace :rspec do
+  SPEC_SUITES.each do |suite|
+    desc "Run #{suite} RSpec code examples"
+    RSpec::Core::RakeTask.new(suite) do |t|
+      t.pattern = "spec/#{suite}/**/*_spec.rb"
+      File.exist?('spec/spec.opts') ? opts = File.read("spec/spec.opts").chomp : opts = ""
+      t.rspec_opts = opts
+    end
+  end
+end

--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -115,18 +115,8 @@ module RSpec::Puppet
     end
 
     def self.safe_create_spec_helper
-      content = <<-EOF
-require 'rspec-puppet'
-
-fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
-
-RSpec.configure do |c|
-  c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests')
-  c.environmentpath = File.join(Dir.pwd, 'spec')
-end
-EOF
-    safe_create_file('spec/spec_helper.rb', content)
+      content = "require 'rspec-puppet/spec_helper'\n"
+      safe_create_file('spec/spec_helper.rb', content)
     end
 
     def self.safe_make_symlink(source, target)
@@ -142,27 +132,7 @@ EOF
 
     def self.safe_create_rakefile
       content = <<-'EOF'
-require 'rake'
-require 'rspec/core/rake_task'
-
-desc "Run all RSpec code examples"
-RSpec::Core::RakeTask.new(:rspec) do |t|
-  File.exist?('spec/spec.opts') ? opts = File.read("spec/spec.opts").chomp : opts = ""
-  t.rspec_opts = opts
-end
-
-SPEC_SUITES = (Dir.entries('spec') - ['.', '..','fixtures']).select {|e| File.directory? "spec/#{e}" }
-namespace :rspec do
-  SPEC_SUITES.each do |suite|
-    desc "Run #{suite} RSpec code examples"
-    RSpec::Core::RakeTask.new(suite) do |t|
-      t.pattern = "spec/#{suite}/**/*_spec.rb"
-      File.exist?('spec/spec.opts') ? opts = File.read("spec/spec.opts").chomp : opts = ""
-      t.rspec_opts = opts
-    end
-  end
-end
-task :default => :rspec
+require 'rspec-puppet/rake_task'
 
 begin
   if Gem::Specification::find_by_name('puppet-lint')
@@ -171,9 +141,10 @@ begin
     task :default => [:rspec, :lint]
   end
 rescue Gem::LoadError
+  task :default => :rspec
 end
 EOF
-    safe_create_file('Rakefile', content)
+      safe_create_file('Rakefile', content)
     end
   end
 end

--- a/lib/rspec-puppet/spec_helper.rb
+++ b/lib/rspec-puppet/spec_helper.rb
@@ -1,0 +1,9 @@
+require 'rspec-puppet'
+
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+
+RSpec.configure do |c|
+  c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.environmentpath = File.join(Dir.pwd, 'spec')
+end


### PR DESCRIPTION
This way the default templates become soothingly stupid and updates to
the files will reach consumers of this code. Special requirements can
still be accommodated by not including these files.

This deliberately leaves the puppet-lint rake task in the template as
that's something people will definitely want to adjust based upon their
local requirements.