### PR TITLE
fix rspec-puppet documentation bug for hiera usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,12 @@ end
 
 ### Configuration
 
+```ruby
+# spec/spec_helper.rb 
+require 'rspec-puppet'
+require 'hiera'
+```
+
 Set the hiera config symbol properly in your spec files:
 
 ```ruby
@@ -441,7 +447,7 @@ user:
 
 ```ruby
   ntpserver = hiera.lookup('ntpserver', nil, nil)
-  let(:params) { :ntpserver => ntpserver }
+  let(:hiera_data) { :ntpserver => ntpserver }
 ```
 
 ### Enabling hiera lookups


### PR DESCRIPTION
http://ask.puppetlabs.com/question/60/what-is-the-recommended-method-for-testing-modules-that-use-hiera/?answer=17865#post-id-17865 

this fix to a bug in the documentation would have saved me a couple of hours today.  

-- Hugh 