### PR TITLE
Fix non-class resource coverage in Puppet > 4.0

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -42,7 +42,7 @@ module RSpec::Puppet
           # test_module's directory tree or the site manifest(s)
           if Puppet.version.to_f >= 4.0
             paths = [
-              (Pathname.new(Puppet[:environmentpath]) + 'fixtures' + test_module + 'manifests').to_s,
+              (Pathname.new(Puppet[:environmentpath]) + 'fixtures' + 'modules' + test_module + 'manifests').to_s,
               (Pathname.new(Puppet[:environmentpath]) + 'fixtures' + 'manifests' + 'site.pp').to_s
             ]
           else


### PR DESCRIPTION
Use the correct test_module manifests path to ensure that directly-
declared resources are correctly marked as requiring coverage.