### PR TITLE
Issue 295:  Allows structured facts to work in 'let :facts' block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Support structured facts with keys as symbols or strings
+
 ## [2.3.0]
 ### Added
 - Custom type testing example group and matcher

--- a/README.md
+++ b/README.md
@@ -364,6 +364,14 @@ You can set them with a hash
 let(:facts) { {:operatingsystem => 'Debian', :kernel => 'Linux', ...} }
 ```
 
+Facts may be expressed as a value (shown in the previous example) or a structure.  Fact keys
+may be expressed as either symbols or strings.  A key will be converted to a lower case
+string to align with the Facter standard 
+
+```ruby
+let(:facts) { {:os => { :family => 'RedHat', :release => { :major => '7', :minor => '1', :full => '7.1.1503' } } } }
+```
+
 You can also create a set of default facts provided to all specs in your spec_helper:
 
 ``` ruby

--- a/spec/classes/facts_spec.rb
+++ b/spec/classes/facts_spec.rb
@@ -1,0 +1,146 @@
+require 'spec_helper'
+
+family = 'RedHat'
+
+# The current behavior is to convert a fact name to lower case.  An issue, FACT-777, has been submitted as a bug
+# with the description of "Facter should not downcast fact names".  The "mixed case in facts" tests this functionality.
+
+describe 'structured_facts::hash' do
+
+  context 'symbols and strings in facts', :if => Puppet.version.to_f >= 4.0 do
+    let(:facts) {{
+      :os => {
+        'family' => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::hash') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  context 'only symbols in facts', :if => Puppet.version.to_f >= 4.0 do
+    let(:facts) {{
+      :os => {
+        :family => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::hash') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  # See note concerning mixed case in facts at the beginning of the file
+  context 'mixed case symbols in facts', :if => Puppet.version.to_f >= 4.0 do
+    let(:facts) {{
+      :os => {
+        :FaMiLy => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::hash') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  context 'only strings in facts', :if => Puppet.version.to_f >= 4.0 do
+    let(:facts) {{
+      'os' => {
+        'family' => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::hash') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  # See note concerning mixed case in facts at the beginning of the file
+  context 'mixed case strings in facts', :if => Puppet.version.to_f >= 4.0 do
+    let(:facts) {{
+      'os' => {
+        'FaMiLy' => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::hash') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+end
+
+describe 'structured_facts::top_scope' do
+
+  context 'symbols and strings in facts' do
+    let(:facts) {{
+      :os => {
+        'family' => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::top_scope') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  context 'only symbols in facts' do
+    let(:facts) {{
+      :os => {
+        :family => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::top_scope') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  # See note concerning mixed case in facts at the beginning of the file
+  context 'mixed case in facts' do
+    let(:facts) {{
+      :os => {
+        :FaMiLy => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::top_scope') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  context 'only string in facts' do
+    let(:facts) {{
+      'os' => {
+        'family' => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::top_scope') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+
+  # See note concerning mixed case in facts at the beginning of the file
+  context 'mixed case in facts' do
+    let(:facts) {{
+      'os' => {
+        'FaMiLy' => family
+      }
+    }}
+
+    it { should contain_class('structured_facts::top_scope') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify(family) }
+  end
+end

--- a/spec/fixtures/modules/structured_facts/manifests/hash.pp
+++ b/spec/fixtures/modules/structured_facts/manifests/hash.pp
@@ -1,0 +1,5 @@
+class structured_facts::hash {
+  $_os_family = $facts['os']['family']
+  notify { "$_os_family": }
+}
+

--- a/spec/fixtures/modules/structured_facts/manifests/top_scope.pp
+++ b/spec/fixtures/modules/structured_facts/manifests/top_scope.pp
@@ -1,0 +1,4 @@
+class structured_facts::top_scope {
+  $_os_family = $::os['family']
+  notify { "$_os_family": }
+}


### PR DESCRIPTION
The change will

* allow structured facts tow work in 'let :facts' block as described in Issue 295
* when using symbols in the facts block, converts symbols to strings throughout rather than just the top-level key

If you would prefer, I could create an issue for the latter and submit it independently.
