### PR TITLE
Catalogue cache improvements

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -2,6 +2,7 @@ module RSpec::Puppet
   module Support
 
     @@cache = {}
+    @@cache_lra = []
 
     def subject
       lambda { catalogue }
@@ -224,7 +225,19 @@ module RSpec::Puppet
     end
 
     def build_catalog(*args)
-      @@cache[args] ||= self.build_catalog_without_cache(*args)
+      unless @@cache.has_key? args
+        @@cache[args] = self.build_catalog_without_cache(*args)
+        @@cache_lra << args
+
+        # Keep only the most recently added 16 entries to prevent high memory consumption
+        expire_cache(@@cache, @@cache_lra, 16)
+      end
+      @@cache[args]
+    end
+
+    def expire_cache(cache, lra, max)
+      expired = lra.slice!(0, lra.size - max)
+      expired.each { |key| cache.delete(key) } if expired
     end
 
     # Facter currently supports lower case facts.  Bug FACT-777 has been submitted to support case sensitive

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -197,7 +197,7 @@ module RSpec::Puppet
 
       stub_facts! facts_val
 
-      node_facts = Puppet::Node::Facts.new(nodename, facts_val)
+      node_facts = Puppet::Node::Facts.new(nodename, facts_val.dup)
 
       node_obj = Puppet::Node.new(nodename, { :parameters => facts_val, :facts => node_facts })
 

--- a/spec/classes/catalogue_cache_spec.rb
+++ b/spec/classes/catalogue_cache_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'test::bare_class' do
+  describe 'cache between adjacent examples' do
+    catalogue_id = nil
+
+    it 'records the initial catalogue ID' do
+      catalogue_id = catalogue.object_id
+    end
+
+    it 'should contain the same catalogue ID' do
+      expect(catalogue.object_id).to eq(catalogue_id)
+    end
+  end
+
+  describe 'cache multiple catalogues' do
+    catalogue_ids = {}
+
+    (1..10).each do |i|
+      context "iteration #{i}" do
+        let(:facts) do
+          { 'iteration' => i }
+        end
+
+        it 'records the initial catalogue ID' do
+          catalogue_ids[i] = catalogue.object_id
+        end
+      end
+    end
+
+    (1..10).each do |i|
+      context "iteration #{i}" do
+        let(:facts) do
+          { 'iteration' => i }
+        end
+
+        it 'should contain the same catalogue ID' do
+          expect(catalogue.object_id).to eq(catalogue_ids[i])
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/catalogue_cache_spec.rb
+++ b/spec/classes/catalogue_cache_spec.rb
@@ -40,4 +40,44 @@ describe 'test::bare_class' do
       end
     end
   end
+
+  describe 'limits number of cached catalogues' do
+    catalogue_ids = {}
+
+    (1..20).each do |i|
+      context "iteration #{i}" do
+        let(:facts) do
+          { 'iteration' => i }
+        end
+
+        it 'records the initial catalogue ID' do
+          catalogue_ids[i] = catalogue.object_id
+        end
+      end
+    end
+
+    (1..4).each do |i|
+      context "iteration #{i}" do
+        let(:facts) do
+          { 'iteration' => i }
+        end
+
+        it 'should receive a new catalogue ID' do
+          expect(catalogue.object_id).not_to eq(catalogue_ids[i])
+        end
+      end
+    end
+
+    (9..20).each do |i|
+      context "iteration #{i}" do
+        let(:facts) do
+          { 'iteration' => i }
+        end
+
+        it 'should contain the same catalogue ID' do
+          expect(catalogue.object_id).to eq(catalogue_ids[i])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes two issues in the catalogue cache:

1) Clones the facts hash to stop the `_timestamp` fact (dynamically generated by Puppet 3.x) from being part of the cache key.  This was preventing the catalogue cache from having any effect on adjacent examples on 3.x.  [Puppet 4 no longer adds this fact](https://tickets.puppetlabs.com/browse/PUP-3130).

2) Limits the size of the cache, preventing memory exhaustion when many different sets of facts and parameters were tested.

Originally reported at https://github.com/rodjek/rspec-puppet/issues/215#issuecomment-145708335.

I'm not sure about the choice of 16 catalogues.  I was tempted to only cache a single catalogue, which would allow adjacent examples (with identical parameters) to get the benefit of caching, but I suppose this might allow for some caching in more complex specs with non-linear layouts of examples (e.g. testing parameter A, then parameter B, then parameter A again).