### PR TITLE
Remove catalogue cache instance variables after each example

### DIFF
--- a/lib/rspec-puppet/example.rb
+++ b/lib/rspec-puppet/example.rb
@@ -40,4 +40,7 @@ RSpec::configure do |c|
     c.include RSpec::Puppet::ProviderExampleGroup, :type => :provider, :file_path => c.escaped_path(%w[spec providers])
   end
 
+  # Hook for each example group type to remove any caches or instance variables, since they will remain
+  # and cause a memory leak.  Can't be assigned per type by :file_path, so check for its presence.
+  c.after(:each) { rspec_puppet_cleanup if respond_to?(:rspec_puppet_cleanup) }
 end

--- a/lib/rspec-puppet/example/class_example_group.rb
+++ b/lib/rspec-puppet/example/class_example_group.rb
@@ -6,5 +6,9 @@ module RSpec::Puppet
     def catalogue
       @catalogue ||= load_catalogue(:class)
     end
+
+    def rspec_puppet_cleanup
+      @catalogue = nil
+    end
   end
 end

--- a/lib/rspec-puppet/example/define_example_group.rb
+++ b/lib/rspec-puppet/example/define_example_group.rb
@@ -6,5 +6,9 @@ module RSpec::Puppet
     def catalogue
       @catalogue ||= load_catalogue(:define)
     end
+
+    def rspec_puppet_cleanup
+      @catalogue = nil
+    end
   end
 end

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -35,6 +35,12 @@ module RSpec::Puppet
       @catalogue ||= compiler.catalog
     end
 
+    def rspec_puppet_cleanup
+      @catalogue = nil
+      @compiler = nil
+      @scope = nil
+    end
+
     private
 
     def compiler

--- a/lib/rspec-puppet/example/host_example_group.rb
+++ b/lib/rspec-puppet/example/host_example_group.rb
@@ -6,5 +6,9 @@ module RSpec::Puppet
     def catalogue
       @catalogue ||= load_catalogue(:host)
     end
+
+    def rspec_puppet_cleanup
+      @catalogue = nil
+    end
   end
 end

--- a/lib/rspec-puppet/example/type_example_group.rb
+++ b/lib/rspec-puppet/example/type_example_group.rb
@@ -19,5 +19,8 @@ module RSpec::Puppet
       end
     end
 
+    def rspec_puppet_cleanup
+      @type_and_resource = nil
+    end
   end
 end

--- a/spec/classes/cleanup_spec.rb
+++ b/spec/classes/cleanup_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe '#rspec_puppet_cleanup' do
+  it { expect(respond_to?(:rspec_puppet_cleanup)).to be true }
+
+  it 'should wipe @catalogue' do
+    @catalogue = Object.new
+    rspec_puppet_cleanup
+    expect(@catalogue).to be_nil
+  end
+end

--- a/spec/defines/cleanup_spec.rb
+++ b/spec/defines/cleanup_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe '#rspec_puppet_cleanup' do
+  it { expect(respond_to?(:rspec_puppet_cleanup)).to be true }
+
+  it 'should wipe @catalogue' do
+    @catalogue = Object.new
+    rspec_puppet_cleanup
+    expect(@catalogue).to be_nil
+  end
+end

--- a/spec/functions/cleanup_spec.rb
+++ b/spec/functions/cleanup_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe '#rspec_puppet_cleanup' do
+  it { expect(respond_to?(:rspec_puppet_cleanup)).to be true }
+
+  it 'should wipe @catalogue' do
+    @catalogue = Object.new
+    @compiler = Object.new
+    @scope = Object.new
+    rspec_puppet_cleanup
+    expect(@catalogue).to be_nil
+    expect(@compiler).to be_nil
+    expect(@scope).to be_nil
+  end
+end

--- a/spec/hosts/cleanup_spec.rb
+++ b/spec/hosts/cleanup_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe '#rspec_puppet_cleanup' do
+  it { expect(respond_to?(:rspec_puppet_cleanup)).to be true }
+
+  it 'should wipe @catalogue' do
+    @catalogue = Object.new
+    rspec_puppet_cleanup
+    expect(@catalogue).to be_nil
+  end
+end

--- a/spec/types/cleanup_spec.rb
+++ b/spec/types/cleanup_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe '#rspec_puppet_cleanup' do
+  it { expect(respond_to?(:rspec_puppet_cleanup)).to be true }
+
+  it 'should wipe @catalogue' do
+    @type_and_resource = Object.new
+    rspec_puppet_cleanup
+    expect(@type_and_resource).to be_nil
+  end
+end


### PR DESCRIPTION
Example groups provided by rspec-puppet use caching within instance
variables for catalogues, compilers etc., but these result in a memory
leak when large numbers of example groups and large catalogues are used.

rspec keeps the example group instance in memory until the end of the
suite and instance variables will simply remain too.  Clearing them
allows unused catalogues to be GCed.

theforeman/puppet was seeing process sizes of at least 3-4GB before
OOMing under MRI Ruby 2.0.0 and 2,416 examples.  This change allows it
to execute the suite with a max resident size of under 1GB.

---

#329 didn't fully fix our OOM issues.  I think it probably reduced the number of catalogues generated and fixed some tests, but left others.

Before this PR: https://travis-ci.org/theforeman/puppet-puppet/builds/93412213 ("Killed"/OOMs on Ruby 2.0.0)
With this PR: https://travis-ci.org/domcleal/puppet-puppet/builds/93687348