### PR TITLE
Fix expected argument mismatch message on Puppet 4.3.0

### DIFF
--- a/spec/functions/split_spec.rb
+++ b/spec/functions/split_spec.rb
@@ -10,7 +10,9 @@ describe 'split' do
     expected_error = Puppet::ParseError
   end
 
-  if Puppet.version.to_f >= 4.0
+  if Puppet.version.to_f >= 4.3
+    expected_error_message = /expects \d+ arguments/
+  elsif Puppet.version.to_f >= 4.0
     expected_error_message = /mis-matched arguments/
   else
     expected_error_message = /number of arguments/


### PR DESCRIPTION
The exception message raised under Puppet 4.3.0 for arity mismatches in
functions changed:

    expected split("foo") to have raised ArgumentError matching /mis-matched arguments/
    instead of ArgumentError('split' expects 2 arguments, got 1)