### PR TITLE
Allow undef parameter passing with symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,12 @@ let(:title) { 'foo' }
 let(:params) { {:ensure => 'present', ...} }
 ```
 
+##### Passing Puppet's `undef` as a parameter value
+
+```ruby
+let(:params) { {:user => :undef, ...} }
+```
+
 #### Specifying the FQDN of the test node
 
 If the manifest you're testing expects to run on host with a particular name,

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -122,8 +122,13 @@ module RSpec::Puppet
 
     def param_str
       params.keys.map do |r|
-        param_val = escape_special_chars(params[r].inspect)
-        "#{r.to_s} => #{param_val}"
+        param_val = params[r]
+        param_val_str = if param_val == :undef
+                          'undef'  # verbatim undef keyword
+                        else
+                          escape_special_chars(param_val.inspect)
+                        end
+        "#{r.to_s} => #{param_val_str}"
       end.join(', ')
     end
 

--- a/spec/classes/undef_spec.rb
+++ b/spec/classes/undef_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'undef_test' do
+  it { should compile.with_all_deps }
+
+  shared_examples 'exec echo' do
+    it { should contain_exec('/bin/echo foo').with_user(nil) }
+  end
+
+  context 'with user => undef' do
+    let(:params) { { :user => :undef } }
+    include_examples 'exec echo'
+  end
+
+  context 'with params unset' do
+    include_examples 'exec echo'
+  end
+end

--- a/spec/defines/undef_def_spec.rb
+++ b/spec/defines/undef_def_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'undef_test::def' do
+  let(:title) { '/bin/echo foo' }
+
+  it { should compile.with_all_deps }
+
+  shared_examples 'exec echo' do
+    it { should contain_exec('/bin/echo foo').with_user(nil) }
+  end
+
+  context 'with user => undef' do
+    let(:params) { { :user => :undef } }
+    include_examples 'exec echo'
+  end
+
+  context 'with params unset' do
+    include_examples 'exec echo'
+  end
+end

--- a/spec/fixtures/modules/undef_test/manifests/def.pp
+++ b/spec/fixtures/modules/undef_test/manifests/def.pp
@@ -1,0 +1,5 @@
+define undef_test::def($user = undef) {
+  exec { '/bin/echo foo':
+    user => $user,
+  }
+}

--- a/spec/fixtures/modules/undef_test/manifests/init.pp
+++ b/spec/fixtures/modules/undef_test/manifests/init.pp
@@ -1,0 +1,5 @@
+class undef_test($user = undef) {
+  exec { '/bin/echo foo':
+    user => $user,
+  }
+}


### PR DESCRIPTION
Now, when a symbol is used as a param value, its `inspect` method is not
called to construct the Puppet parameter value. Instead, the unquoted
string, e.g. `undef` is used in the generated resource declaration. So now
`let(:params) { { :foo => :undef } }` leads to the desired resource
declaration `class { 'test': foo => undef }`.

Before this change, it was impossible to pass `undef` as a parameter.
Using `nil`, `:undef`, or `'undef'` all failed for various reasons.

Credit to the discussion at [1] for identifying the issue and proposing
an alternate solution.

Fixes #279.

[1] <https://groups.google.com/forum/#!topic/puppet-users/6nL2eROH8is>

Adapted by Dominic Cleal from https://github.com/rodjek/rspec-puppet/pull/280 to use symbols instead of nil.

---

Replaces #280.  The idea of using a class is OK as a workaround, but unnecessary I think for proper support in rspec-puppet.  Using a symbol - which has no function in r-p today, as #inspect generates an invalid Puppet DSL string - seems lightweight and may have other uses in future.

I can imagine using it to pass more complex verbatim strings in, e.g. `let(:params) { {:param => :'file(..)'} }` or similar.