### PR TITLE
Extract cache class from support mixin

### DIFF
--- a/lib/rspec-puppet/cache.rb
+++ b/lib/rspec-puppet/cache.rb
@@ -1,0 +1,30 @@
+module RSpec::Puppet
+  class Cache
+
+    MAX_ENTRIES = 16
+
+    # @param [Proc] default_proc The default proc to use to fetch objects on cache miss
+    def initialize(&default_proc)
+      @default_proc = default_proc
+      @cache = {}
+      @lra = []
+    end
+
+    def get(*args, &blk)
+      if !@cache.has_key? args
+        @cache[args] = (blk || @default_proc).call(*args)
+        @lra << args
+        expire!
+      end
+
+      @cache[args]
+    end
+
+    private
+
+    def expire!
+      expired = @lra.slice!(0, @lra.size - MAX_ENTRIES)
+      expired.each { |key| @cache.delete(key) } if expired
+    end
+  end
+end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'rspec-puppet/cache'
+
+describe RSpec::Puppet::Cache do
+
+  let(:compiler) { Hash.new }
+
+  subject do
+    described_class.new do |args|
+      compiler[args]
+    end
+  end
+
+  describe "fetching cached entries" do
+    it "calls the get_proc on cache misses" do
+      compiler["example.com"] = "New catalog!"
+      fetched_obj = subject.get("example.com")
+      expect(fetched_obj).to eq("New catalog!")
+    end
+
+    it "can supply a proc to the get method" do
+      compiler["example.com"] = "New catalog!"
+      fetched_obj = subject.get("example.com") do |args|
+        compiler[args] + "!!"
+      end
+      expect(fetched_obj).to eq("New catalog!!!")
+    end
+
+    it "can handle procs with multiple args" do
+      compiler["example.com"] = "New catalog!"
+      fetched_obj = subject.get("example.com", " Yay!") do |arg1, arg2|
+        compiler[arg1] + arg2
+      end
+      expect(fetched_obj).to eq("New catalog! Yay!")
+    end
+
+    it "reuses cached entries" do
+      compiler["example.com"] = "Cachable catalog!"
+
+      first = subject.get("example.com")
+      second = subject.get("example.com")
+
+      expect(first.object_id).to eq(second.object_id)
+    end
+
+    it "evicts expired entries" do
+      compiler["evicting.example.com"] = "Catalog to evict"
+      0.upto(15) do |i|
+        compiler["node#{i}.example.com"] = "Catalog for node #{i}"
+      end
+
+      first = subject.get("evicting.example.com")
+      0.upto(15) do |i|
+        subject.get("node#{i}.example.com")
+      end
+      compiler["evicting.example.com"] = "Replacement catalog"
+      second = subject.get("evicting.example.com")
+
+      expect(first).to eq("Catalog to evict")
+      expect(second).to eq("Replacement catalog")
+
+    end
+  end
+end


### PR DESCRIPTION
The RSpec::Puppet::Support mixin has become a god object and has gobs of
unrelated functionality, making it hard to extend/refactor/improve. This
commit starts simplifying it by extracting a real cache object to a
class and using that instead of the inline cache.