### PR TITLE
Extract version specific Puppet functionality

### DIFF
--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -26,6 +26,10 @@ module RSpec::Puppet
       def catalog(node, _)
         Puppet::Resource::Catalog.indirection.find(node.name, :use_node => node)
       end
+
+      def environment(name)
+        Puppet::Node::Environment.new(name)
+      end
     end
 
     class Adapter4X < Base
@@ -40,8 +44,8 @@ module RSpec::Puppet
         ]
       end
 
-      def catalog(node, environment)
-        env = build_4x_environment(environment)
+      def catalog(node, environment_name)
+        env = environment(environment_name)
         loader = Puppet::Environments::Static.new(env)
         Puppet.override({:environments => loader}, 'Setup test environment') do
           node.environment = env
@@ -49,9 +53,7 @@ module RSpec::Puppet
         end
       end
 
-      private
-
-      def build_4x_environment(name)
+      def environment(name)
         modulepath = RSpec.configuration.module_path || File.join(Puppet[:environmentpath], 'fixtures', 'modules')
         manifest = RSpec.configuration.manifest || File.join(Puppet[:environmentpath], 'fixtures', 'manifests')
         Puppet::Node::Environment.create(name, [modulepath], manifest)

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -30,18 +30,23 @@ module RSpec::Puppet
       def environment(name)
         Puppet::Node::Environment.new(name)
       end
+
+      def settings_map
+        [
+          [:modulepath, :module_path],
+          [:config, :config],
+          [:confdir, :confdir],
+        ]
+      end
     end
 
     class Adapter4X < Base
       def settings_map
-        [
-          [:modulepath, :module_path],
+        super.concat([
           [:environmentpath, :environmentpath],
-          [:config, :config],
-          [:confdir, :confdir],
           [:hiera_config, :hiera_config],
           [:strict_variables, :strict_variables],
-        ]
+        ])
       end
 
       def catalog(node, environment_name)
@@ -62,33 +67,27 @@ module RSpec::Puppet
 
     class Adapter3X < Base
       def settings_map
-        [
-          [:modulepath, :module_path],
+        super.concat([
           [:manifestdir, :manifest_dir],
           [:manifest, :manifest],
           [:templatedir, :template_dir],
-          [:config, :config],
-          [:confdir, :confdir],
           [:hiera_config, :hiera_config],
           [:parser, :parser],
           [:trusted_node_data, :trusted_node_data],
           [:ordering, :ordering],
           [:stringify_facts, :stringify_facts],
           [:strict_variables, :strict_variables],
-        ]
+        ])
       end
     end
 
     class Adapter27 < Base
       def settings_map
-        [
-          [:modulepath, :module_path],
+        super.concat([
           [:manifestdir, :manifest_dir],
           [:manifest, :manifest],
           [:templatedir, :template_dir],
-          [:config, :config],
-          [:confdir, :confdir],
-        ]
+        ])
       end
     end
 

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -1,0 +1,85 @@
+module RSpec::Puppet
+  module Adapters
+
+    class Base
+      def setup_puppet(example_group)
+        settings_map.each do |puppet_setting, rspec_setting|
+          set_setting(example_group, puppet_setting, rspec_setting)
+        end
+      end
+
+      def set_setting(example_group, puppet_setting, rspec_setting)
+        if example_group.respond_to?(rspec_setting)
+          value = example_group.send(rspec_setting)
+        else
+          value = RSpec.configuration.send(rspec_setting)
+        end
+        begin
+          Puppet[puppet_setting] = value
+        rescue ArgumentError
+          # TODO: this silently swallows errors when applying settings that the current
+          # Puppet version does not accept, which means that user specified settings
+          # are ignored. This may lead to suprising behavior for users.
+        end
+      end
+    end
+
+    class Adapter4X < Base
+      def settings_map
+        [
+          [:modulepath, :module_path],
+          [:environmentpath, :environmentpath],
+          [:config, :config],
+          [:confdir, :confdir],
+          [:hiera_config, :hiera_config],
+          [:strict_variables, :strict_variables],
+        ]
+      end
+    end
+
+    class Adapter3X < Base
+      def settings_map
+        [
+          [:modulepath, :module_path],
+          [:manifestdir, :manifest_dir],
+          [:manifest, :manifest],
+          [:templatedir, :template_dir],
+          [:config, :config],
+          [:confdir, :confdir],
+          [:hiera_config, :hiera_config],
+          [:parser, :parser],
+          [:trusted_node_data, :trusted_node_data],
+          [:ordering, :ordering],
+          [:stringify_facts, :stringify_facts],
+          [:strict_variables, :strict_variables],
+        ]
+      end
+    end
+
+    class Adapter27 < Base
+      def settings_map
+        [
+          [:modulepath, :module_path],
+          [:manifestdir, :manifest_dir],
+          [:manifest, :manifest],
+          [:templatedir, :template_dir],
+          [:config, :config],
+          [:confdir, :confdir],
+        ]
+      end
+    end
+
+    def self.get
+      [
+        [4.0, Adapter4X],
+        [3.0, Adapter3X],
+        [2.7, Adapter27]
+      ].each do |(version, klass)|
+        if Puppet.version.to_f >= version
+          return klass.new
+        end
+      end
+      raise "Puppet version #{Puppet.version.to_f} is not supported."
+    end
+  end
+end

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -10,7 +10,7 @@ module RSpec::Puppet
       vardir = setup_puppet
 
       if Puppet.version.to_f >= 4.0
-        env = build_4x_environment(environment)
+        env = adapter.environment(environment)
         loader = Puppet::Pops::Loaders.new(env)
         func = loader.private_environment_loader.load(:function,function_name)
         return func if func
@@ -87,11 +87,7 @@ module RSpec::Puppet
     end
 
     def build_node(name, opts = {})
-      if Puppet.version.to_f >= 4.0
-        node_environment = build_4x_environment(environment)
-      else
-        node_environment = Puppet::Node::Environment.new(environment)
-      end
+      node_environment = adapter.environment(environment)
       opts.merge!({:environment => node_environment})
       Puppet::Node.new(name, opts)
     end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -168,19 +168,7 @@ module RSpec::Puppet
 
       node_obj = Puppet::Node.new(nodename, { :parameters => facts_val, :facts => node_facts })
 
-      # trying to be compatible with 2.7 as well as 2.6
-      if Puppet::Resource::Catalog.respond_to? :find
-        Puppet::Resource::Catalog.find(node_obj.name, :use_node => node_obj)
-      elsif Puppet.version.to_f >= 4.0
-        env = build_4x_environment(environment)
-        loader = Puppet::Environments::Static.new(env)
-        Puppet.override({:environments => loader}, 'Setup test environment') do
-          node_obj.environment = env
-          Puppet::Resource::Catalog.indirection.find(node_obj.name, :use_node => node_obj)
-        end
-      else
-        Puppet::Resource::Catalog.indirection.find(node_obj.name, :use_node => node_obj)
-      end
+      @adapter.catalog(node_obj, environment)
     end
 
     def stub_facts!(facts)

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -208,12 +208,6 @@ module RSpec::Puppet
       end
     end
 
-    def build_4x_environment(name)
-      modulepath = RSpec.configuration.module_path || File.join(Puppet[:environmentpath], 'fixtures', 'modules')
-      manifest = RSpec.configuration.manifest || File.join(Puppet[:environmentpath], 'fixtures', 'manifests')
-      Puppet::Node::Environment.create(name, [modulepath], manifest)
-    end
-
     def adapter
       @adapter ||= RSpec::Puppet::Adapters.get
     end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -168,7 +168,7 @@ module RSpec::Puppet
 
       node_obj = Puppet::Node.new(nodename, { :parameters => facts_val, :facts => node_facts })
 
-      @adapter.catalog(node_obj, environment)
+      adapter.catalog(node_obj, environment)
     end
 
     def stub_facts!(facts)

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -35,7 +35,7 @@ describe RSpec::Puppet::Support do
       end
     end
 
-    context 'when running on puppet 3.x, with x >= 5', :if => Puppet.version.to_f >= 3.5 && Puppet.version.to_f < 4.0 do
+    context 'when running on puppet 3.x, with x >= 5', :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
       it 'sets Puppet[:trusted_node_data] to false by default' do
         subject.setup_puppet
         expect(Puppet[:trusted_node_data]).to eq(false)
@@ -47,29 +47,36 @@ describe RSpec::Puppet::Support do
       end
     end
 
-    context 'when running on puppet 3', :if => Puppet.version.to_f >= 3.0 && Puppet.version.to_f < 4.0 do
+    context 'when running on puppet ~> 3.2', :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
       it 'sets Puppet[:parser] to "current" by default' do
         subject.setup_puppet
         expect(Puppet[:parser]).to eq("current")
       end
+
       it 'reads the :parser setting' do
         allow(subject).to receive(:parser).and_return("future")
         subject.setup_puppet
         expect(Puppet[:parser]).to eq("future")
       end
+    end
+
+    context 'when running on puppet ~> 3.3', :if => (3.3 ... 4.0).include?(Puppet.version.to_f) do
       it 'sets Puppet[:stringify_facts] to true by default' do
         subject.setup_puppet
         expect(Puppet[:stringify_facts]).to eq(true)
       end
+
       it 'reads the :stringify_facts setting' do
         allow(subject).to receive(:stringify_facts).and_return(false)
         subject.setup_puppet
         expect(Puppet[:stringify_facts]).to eq(false)
       end
+
       it 'sets Puppet[:ordering] to title-hash by default' do
         subject.setup_puppet
         expect(Puppet[:ordering]).to eq('title-hash')
       end
+
       it 'reads the :ordering setting' do
         allow(subject).to receive(:ordering).and_return('manifest')
         subject.setup_puppet


### PR DESCRIPTION
The rspec-puppet codebase is littered with code that changes behavior based on what version of Puppet is available; this makes the code harder to understand and reason about, increases the cost of maintenance, and frequently leads to code duplication. This pull request is an initial attempt to pull version specific behavior into a series of classes that can share common behavior and override version specific behavior at a single point.