### PR TITLE
GH-343: Support colon separated modulepaths and environmentpaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 /Gemfile.lock
+/Gemfile.local
 /.bundle/
 /vendor/
 .ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,7 @@ gem 'pry', :group => :development
 if ENV['COVERAGE'] == 'yes'
   gem 'coveralls', :require => false
 end
+
+if File.exist?('Gemfile.local')
+  eval_gemfile('Gemfile.local')
+end

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -29,6 +29,7 @@ RSpec.configure do |c|
   c.add_setting :ordering, :default => 'title-hash'
   c.add_setting :stringify_facts, :default => true
   c.add_setting :strict_variables, :default => false
+  c.add_setting :adapter
 
   if defined?(Puppet::Test::TestHelper)
     begin
@@ -70,6 +71,7 @@ RSpec.configure do |c|
     if self.class.ancestors.include? RSpec::Puppet::Support
       @adapter = RSpec::Puppet::Adapters.get
       @adapter.setup_puppet(self)
+      c.adapter = adapter
     end
   end
 end

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -7,6 +7,7 @@ require 'rspec-puppet/matchers'
 require 'rspec-puppet/example'
 require 'rspec-puppet/setup'
 require 'rspec-puppet/coverage'
+require 'rspec-puppet/adapters'
 
 begin
   require 'puppet/test/test_helper'
@@ -62,6 +63,13 @@ RSpec.configure do |c|
         Puppet::Test::TestHelper.after_each_test
       rescue
       end
+    end
+  end
+
+  c.before :each do
+    if self.class.ancestors.include? RSpec::Puppet::Support
+      @adapter = RSpec::Puppet::Adapters.get
+      @adapter.setup_puppet(self)
     end
   end
 end

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -10,6 +10,7 @@ module RSpec::Puppet
         settings_map.each do |puppet_setting, rspec_setting|
           set_setting(example_group, puppet_setting, rspec_setting)
         end
+        @environment_name = example_group.environment
       end
 
       # Set up a specific Puppet setting.
@@ -65,12 +66,12 @@ module RSpec::Puppet
         end
       end
 
-      def catalog(node, _)
+      def catalog(node)
         Puppet::Resource::Catalog.indirection.find(node.name, :use_node => node)
       end
 
-      def environment(name)
-        Puppet::Node::Environment.new(name)
+      def current_environment
+        Puppet::Node::Environment.new(@environment_name)
       end
 
       def settings_map
@@ -91,8 +92,8 @@ module RSpec::Puppet
         ])
       end
 
-      def catalog(node, environment_name)
-        env = environment(environment_name)
+      def catalog(node)
+        env = current_environment
         loader = Puppet::Environments::Static.new(env)
         Puppet.override({:environments => loader}, 'Setup test environment') do
           node.environment = env
@@ -100,10 +101,10 @@ module RSpec::Puppet
         end
       end
 
-      def environment(name)
+      def current_environment
         modulepath = RSpec.configuration.module_path || File.join(Puppet[:environmentpath], 'fixtures', 'modules')
         manifest = RSpec.configuration.manifest || File.join(Puppet[:environmentpath], 'fixtures', 'manifests')
-        Puppet::Node::Environment.create(name, [modulepath], manifest)
+        Puppet::Node::Environment.create(@environment_name, [modulepath], manifest)
       end
     end
 

--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -130,16 +130,11 @@ module RSpec::Puppet
     #
     # @return [Array<String>]
     def module_paths(test_module)
-      if Puppet.version.to_f >= 4.0
-        modulepath = RSpec.configuration.module_path || File.join(Puppet[:environmentpath], 'fixtures', 'modules')
-        manifest = RSpec.configuration.manifest || File.join(Puppet[:environmentpath], 'fixtures', 'manifests', 'site.pp')
-        paths = [File.join(modulepath, test_module, 'manifests'), manifest]
-      else
-        paths = Puppet[:modulepath].split(File::PATH_SEPARATOR).map do |dir|
-          File.join(dir, test_module, 'manifests')
-        end
-        paths << Puppet[:manifest]
+      adapter = RSpec.configuration.adapter
+      paths = adapter.modulepath.map do |dir|
+        File.join(dir, test_module, 'manifests')
       end
+      paths << adapter.manifest
       paths
     end
 

--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -134,7 +134,7 @@ module RSpec::Puppet
       paths = adapter.modulepath.map do |dir|
         File.join(dir, test_module, 'manifests')
       end
-      paths << adapter.manifest
+      paths << adapter.manifest if adapter.manifest
       paths
     end
 

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -10,7 +10,7 @@ module RSpec::Puppet
       vardir = setup_puppet
 
       if Puppet.version.to_f >= 4.0
-        env = adapter.environment(environment)
+        env = adapter.current_environment
         loader = Puppet::Pops::Loaders.new(env)
         func = loader.private_environment_loader.load(:function,function_name)
         return func if func
@@ -87,7 +87,7 @@ module RSpec::Puppet
     end
 
     def build_node(name, opts = {})
-      node_environment = adapter.environment(environment)
+      node_environment = adapter.current_environment
       opts.merge!({:environment => node_environment})
       Puppet::Node.new(name, opts)
     end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -39,7 +39,7 @@ module RSpec::Puppet
 
     def import_str
       import_str = ""
-      Puppet[:modulepath].split(File::PATH_SEPARATOR).each { |d|
+      adapter.modulepath.each { |d|
         if File.exists?(File.join(d, 'manifests', 'init.pp'))
           path_to_manifest = File.join([
             d,
@@ -53,7 +53,7 @@ module RSpec::Puppet
           ].join("\n")
           break
         elsif File.exists?(d)
-          import_str = "import '#{Puppet[:manifest]}'\n"
+          import_str = "import '#{adapter.manifest}'\n"
           break
         end
       }
@@ -138,7 +138,7 @@ module RSpec::Puppet
       vardir = Dir.mktmpdir
       Puppet[:vardir] = vardir
 
-      Puppet[:modulepath].split(File::PATH_SEPARATOR).map do |d|
+      adapter.modulepath.map do |d|
         Dir["#{d}/*/lib"].entries
       end.flatten.each do |lib|
         $LOAD_PATH << lib
@@ -206,6 +206,9 @@ module RSpec::Puppet
       end
     end
 
-    attr_reader :adapter
+    # @!attribute [r] adapter
+    #   @api private
+    #   @return [Class < RSpec::Puppet::Adapters::Base]
+    attr_accessor :adapter
   end
 end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -138,8 +138,6 @@ module RSpec::Puppet
       vardir = Dir.mktmpdir
       Puppet[:vardir] = vardir
 
-      adapter.setup_puppet(self)
-
       Puppet[:modulepath].split(File::PATH_SEPARATOR).map do |d|
         Dir["#{d}/*/lib"].entries
       end.flatten.each do |lib|
@@ -208,8 +206,6 @@ module RSpec::Puppet
       end
     end
 
-    def adapter
-      @adapter ||= RSpec::Puppet::Adapters.get
-    end
+    attr_reader :adapter
   end
 end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -166,7 +166,7 @@ module RSpec::Puppet
 
       node_obj = Puppet::Node.new(nodename, { :parameters => facts_val, :facts => node_facts })
 
-      adapter.catalog(node_obj, environment)
+      adapter.catalog(node_obj)
     end
 
     def stub_facts!(facts)

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -8,7 +8,7 @@ describe RSpec::Puppet::Support do
 
   describe '#setup_puppet' do
     before do
-      RSpec::Puppet::Adapters.get.setup_puppet(self)
+      RSpec::Puppet::Adapters.get.setup_puppet(subject)
     end
 
     it 'updates the ruby $LOAD_PATH based on the current modulepath' do

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -2,14 +2,10 @@ require 'spec_helper'
 
 describe RSpec::Puppet::Support do
   subject do
-    klass = Class.new do
-      include RSpec::Puppet::Support
-    end
-    klass.new
+    Object.new.extend(RSpec::Puppet::Support)
   end
 
   describe '#setup_puppet' do
-
     it 'updates the ruby $LOAD_PATH based on the current modulepath' do
       basedir = RSpec.configuration.module_path
 
@@ -21,79 +17,6 @@ describe RSpec::Puppet::Support do
 
       expect($LOAD_PATH).to include(dira)
       expect($LOAD_PATH).to include(dirb)
-    end
-
-    context 'when running on puppet 3.5 or later', :if => Puppet.version.to_f >= 3.5 do
-      it 'sets Puppet[:strict_variables] to false by default' do
-        subject.setup_puppet
-        expect(Puppet[:strict_variables]).to eq(false)
-      end
-      it 'reads the :strict_variables setting' do
-        allow(subject).to receive(:strict_variables).and_return(true)
-        subject.setup_puppet
-        expect(Puppet[:strict_variables]).to eq(true)
-      end
-    end
-
-    context 'when running on puppet 3.x, with x >= 5', :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
-      it 'sets Puppet[:trusted_node_data] to false by default' do
-        subject.setup_puppet
-        expect(Puppet[:trusted_node_data]).to eq(false)
-      end
-      it 'reads the :trusted_node_data setting' do
-        allow(subject).to receive(:trusted_node_data).and_return(true)
-        subject.setup_puppet
-        expect(Puppet[:trusted_node_data]).to eq(true)
-      end
-    end
-
-    context 'when running on puppet ~> 3.2', :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
-      it 'sets Puppet[:parser] to "current" by default' do
-        subject.setup_puppet
-        expect(Puppet[:parser]).to eq("current")
-      end
-
-      it 'reads the :parser setting' do
-        allow(subject).to receive(:parser).and_return("future")
-        subject.setup_puppet
-        expect(Puppet[:parser]).to eq("future")
-      end
-    end
-
-    context 'when running on puppet ~> 3.3', :if => (3.3 ... 4.0).include?(Puppet.version.to_f) do
-      it 'sets Puppet[:stringify_facts] to true by default' do
-        subject.setup_puppet
-        expect(Puppet[:stringify_facts]).to eq(true)
-      end
-
-      it 'reads the :stringify_facts setting' do
-        allow(subject).to receive(:stringify_facts).and_return(false)
-        subject.setup_puppet
-        expect(Puppet[:stringify_facts]).to eq(false)
-      end
-
-      it 'sets Puppet[:ordering] to title-hash by default' do
-        subject.setup_puppet
-        expect(Puppet[:ordering]).to eq('title-hash')
-      end
-
-      it 'reads the :ordering setting' do
-        allow(subject).to receive(:ordering).and_return('manifest')
-        subject.setup_puppet
-        expect(Puppet[:ordering]).to eq('manifest')
-      end
-    end
-
-    context 'when running on puppet 4', :if => Puppet.version.to_f >= 4.0 do
-      it 'sets Puppet[:strict_variables] to false by default' do
-        subject.setup_puppet
-        expect(Puppet[:strict_variables]).to eq(false)
-      end
-      it 'reads the :strict_variables setting' do
-        allow(subject).to receive(:strict_variables).and_return(true)
-        subject.setup_puppet
-        expect(Puppet[:strict_variables]).to eq(true)
-      end
     end
   end
 end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -8,7 +8,9 @@ describe RSpec::Puppet::Support do
 
   describe '#setup_puppet' do
     before do
-      RSpec::Puppet::Adapters.get.setup_puppet(subject)
+      adapter = RSpec::Puppet::Adapters.get
+      adapter.setup_puppet(subject)
+      subject.adapter = adapter
     end
 
     it 'updates the ruby $LOAD_PATH based on the current modulepath' do

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec-puppet/adapters'
 
 describe RSpec::Puppet::Support do
   subject do
@@ -6,6 +7,10 @@ describe RSpec::Puppet::Support do
   end
 
   describe '#setup_puppet' do
+    before do
+      RSpec::Puppet::Adapters.get.setup_puppet(self)
+    end
+
     it 'updates the ruby $LOAD_PATH based on the current modulepath' do
       basedir = RSpec.configuration.module_path
 

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -142,4 +142,19 @@ describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 d
     subject.setup_puppet(test_context)
     expect(Puppet[:strict_variables]).to eq(true)
   end
+
+  describe '#manifest' do
+    it 'returns the configured environment manifest when set' do
+      allow(RSpec.configuration).to receive(:manifest).and_return("/path/to/manifest")
+      subject.setup_puppet(double(:environment => 'rp_puppet'))
+      expect(subject.manifest).to eq "/path/to/manifest"
+    end
+
+    it 'returns nil when the configured environment manifest is not set' do
+      allow(RSpec.configuration).to receive(:manifest)
+      allow(RSpec.configuration).to receive(:environmentpath).and_return("/some/missing/path:/another/missing/path")
+      subject.setup_puppet(double(:environment => 'rp_puppet'))
+      expect(subject.manifest).to be_nil
+    end
+  end
 end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -69,3 +69,74 @@ describe RSpec::Puppet::Adapters::Base do
     end
   end
 end
+
+describe RSpec::Puppet::Adapters::Adapter3X do
+  context 'when running on puppet 3.5 or later', :if => Puppet.version.to_f >= 3.5 do
+    it 'sets Puppet[:strict_variables] to false by default' do
+      subject.setup_puppet(double)
+      expect(Puppet[:strict_variables]).to eq(false)
+    end
+
+    it 'reads the :strict_variables setting' do
+      subject.setup_puppet(double(:strict_variables => true))
+      expect(Puppet[:strict_variables]).to eq(true)
+    end
+  end
+
+  context 'when running on puppet 3.x, with x >= 5', :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
+    it 'sets Puppet[:trusted_node_data] to false by default' do
+      subject.setup_puppet(double)
+      expect(Puppet[:trusted_node_data]).to eq(false)
+    end
+    it 'reads the :trusted_node_data setting' do
+      subject.setup_puppet(double(:trusted_node_data => true))
+      expect(Puppet[:trusted_node_data]).to eq(true)
+    end
+  end
+
+  context 'when running on puppet ~> 3.2', :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
+    it 'sets Puppet[:parser] to "current" by default' do
+      subject.setup_puppet(double)
+      expect(Puppet[:parser]).to eq("current")
+    end
+
+    it 'reads the :parser setting' do
+      subject.setup_puppet(double(:parser => "future"))
+      expect(Puppet[:parser]).to eq("future")
+    end
+  end
+
+  context 'when running on puppet ~> 3.3', :if => (3.3 ... 4.0).include?(Puppet.version.to_f) do
+    it 'sets Puppet[:stringify_facts] to true by default' do
+      subject.setup_puppet(double)
+      expect(Puppet[:stringify_facts]).to eq(true)
+    end
+
+    it 'reads the :stringify_facts setting' do
+      subject.setup_puppet(double(:stringify_facts => false))
+      expect(Puppet[:stringify_facts]).to eq(false)
+    end
+
+    it 'sets Puppet[:ordering] to title-hash by default' do
+      subject.setup_puppet(double)
+      expect(Puppet[:ordering]).to eq('title-hash')
+    end
+
+    it 'reads the :ordering setting' do
+      subject.setup_puppet(double(:ordering => "manifest"))
+      expect(Puppet[:ordering]).to eq('manifest')
+    end
+  end
+end
+
+describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 do
+  it 'sets Puppet[:strict_variables] to false by default' do
+    subject.setup_puppet(double)
+    expect(Puppet[:strict_variables]).to eq(false)
+  end
+
+  it 'reads the :strict_variables setting' do
+    subject.setup_puppet(double(:strict_variables => true))
+    expect(Puppet[:strict_variables]).to eq(true)
+  end
+end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -4,7 +4,7 @@ require 'rspec-puppet/adapters'
 describe RSpec::Puppet::Adapters::Base do
   describe '#setup_puppet' do
     it "sets up all settings listed in the settings map" do
-      context = Object.new
+      context = double :environment => 'rp_puppet'
       subject.settings_map.each do |puppet_setting, rspec_setting|
         expect(subject).to receive(:set_setting).with(context, puppet_setting, rspec_setting)
       end
@@ -15,20 +15,14 @@ describe RSpec::Puppet::Adapters::Base do
   describe '#set_setting' do
     describe "with a context specific setting" do
       it "sets the Puppet setting based on the example group setting" do
-        context = Object.new
-        def context.confdir
-          "/etc/fingerpuppet"
-        end
+        context = double :confdir => "/etc/fingerpuppet"
         subject.set_setting(context, :confdir, :confdir)
         expect(Puppet[:confdir]).to eq "/etc/fingerpuppet"
       end
 
       it "does not persist settings between example groups" do
-        context1 = Object.new
-        def context1.confdir
-          "/etc/fingerpuppet"
-        end
-        context2 = Object.new
+        context1 = double :confdir => "/etc/fingerpuppet"
+        context2 = double
         subject.set_setting(context1, :confdir, :confdir)
         expect(Puppet[:confdir]).to eq "/etc/fingerpuppet"
         subject.set_setting(context2, :confdir, :confdir)
@@ -42,7 +36,7 @@ describe RSpec::Puppet::Adapters::Base do
       end
 
       it "sets the Puppet setting based on the global configuration value" do
-        subject.set_setting(Object.new, :confdir, :confdir)
+        subject.set_setting(double, :confdir, :confdir)
         expect(Puppet[:confdir]).to eq "/etc/bunraku"
       end
     end
@@ -53,10 +47,7 @@ describe RSpec::Puppet::Adapters::Base do
       end
 
       it "prefers the context specific setting" do
-        context = Object.new
-        def context.confdir
-          "/etc/sockpuppet"
-        end
+        context = double :confdir => "/etc/sockpuppet"
         subject.set_setting(context, :confdir, :confdir)
         expect(Puppet[:confdir]).to eq "/etc/sockpuppet"
       end
@@ -71,72 +62,84 @@ describe RSpec::Puppet::Adapters::Base do
 end
 
 describe RSpec::Puppet::Adapters::Adapter3X do
+
+  let(:test_context) { double :environment => 'rp_env' }
+
   context 'when running on puppet 3.5 or later', :if => Puppet.version.to_f >= 3.5 do
     it 'sets Puppet[:strict_variables] to false by default' do
-      subject.setup_puppet(double)
+      subject.setup_puppet(test_context)
       expect(Puppet[:strict_variables]).to eq(false)
     end
 
     it 'reads the :strict_variables setting' do
-      subject.setup_puppet(double(:strict_variables => true))
+      allow(test_context).to receive(:strict_variables).and_return true
+      subject.setup_puppet(test_context)
       expect(Puppet[:strict_variables]).to eq(true)
     end
   end
 
   context 'when running on puppet 3.x, with x >= 5', :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
     it 'sets Puppet[:trusted_node_data] to false by default' do
-      subject.setup_puppet(double)
+      subject.setup_puppet(test_context)
       expect(Puppet[:trusted_node_data]).to eq(false)
     end
     it 'reads the :trusted_node_data setting' do
-      subject.setup_puppet(double(:trusted_node_data => true))
+      allow(test_context).to receive(:trusted_node_data).and_return(true)
+      subject.setup_puppet(test_context)
       expect(Puppet[:trusted_node_data]).to eq(true)
     end
   end
 
   context 'when running on puppet ~> 3.2', :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
     it 'sets Puppet[:parser] to "current" by default' do
-      subject.setup_puppet(double)
+      subject.setup_puppet(test_context)
       expect(Puppet[:parser]).to eq("current")
     end
 
     it 'reads the :parser setting' do
-      subject.setup_puppet(double(:parser => "future"))
+      allow(test_context).to receive(:parser).and_return("future")
+      subject.setup_puppet(test_context)
       expect(Puppet[:parser]).to eq("future")
     end
   end
 
   context 'when running on puppet ~> 3.3', :if => (3.3 ... 4.0).include?(Puppet.version.to_f) do
     it 'sets Puppet[:stringify_facts] to true by default' do
-      subject.setup_puppet(double)
+      subject.setup_puppet(test_context)
       expect(Puppet[:stringify_facts]).to eq(true)
     end
 
     it 'reads the :stringify_facts setting' do
-      subject.setup_puppet(double(:stringify_facts => false))
+      allow(test_context).to receive(:stringify_facts).and_return false
+      subject.setup_puppet(test_context)
       expect(Puppet[:stringify_facts]).to eq(false)
     end
 
     it 'sets Puppet[:ordering] to title-hash by default' do
-      subject.setup_puppet(double)
+      subject.setup_puppet(test_context)
       expect(Puppet[:ordering]).to eq('title-hash')
     end
 
     it 'reads the :ordering setting' do
-      subject.setup_puppet(double(:ordering => "manifest"))
+      allow(test_context).to receive(:ordering).and_return("manifest")
+      subject.setup_puppet(test_context)
       expect(Puppet[:ordering]).to eq('manifest')
     end
   end
 end
 
 describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 do
+
+  let(:test_context) { double :environment => 'rp_env' }
+
   it 'sets Puppet[:strict_variables] to false by default' do
-    subject.setup_puppet(double)
+    subject.setup_puppet(test_context)
     expect(Puppet[:strict_variables]).to eq(false)
   end
 
   it 'reads the :strict_variables setting' do
-    subject.setup_puppet(double(:strict_variables => true))
+    allow(test_context).to receive(:strict_variables).and_return(true)
+    subject.setup_puppet(test_context)
     expect(Puppet[:strict_variables]).to eq(true)
   end
 end


### PR DESCRIPTION
The addition of Puppet 4 support added a number of separate code paths for Puppet 4. This caused a number of instances to creep in where colon delimited modulepaths were supported, but not on Puppet 4. Moreover Puppet 4 calculates the current modulepath and manifest relative to the current environment, which is quite different from how Puppet 3 and earlier traditionally handled it.

This pull request introduces a number of changes in order to consistently handle modulepaths and manifests across multiple versions of puppet

  * Eagerly initialize Puppet setttings so that the current environment can be set before specs are run
  * Always use the current environment when getting catalogs and functions 
  * Properly set up the Puppet 4.x context with correct environment information
  * Properly split the modulepath on Puppet 3.x
  * Properly split the environmentpath on Puppet 4.x