### PR TITLE
Make caching evict least recently used

### DIFF
--- a/lib/rspec-puppet/cache.rb
+++ b/lib/rspec-puppet/cache.rb
@@ -14,7 +14,7 @@ module RSpec::Puppet
       if @cache.has_key? args
         # Cache hit
         # move that entry last to make it "most recenty used"
-        @ira.insert(-1, @ira.delete_at(@ira.index(args)))
+        @lra.insert(-1, @lra.delete_at(@lra.index(args)))
       else
         # Cache miss
         # Ensure room by evicting least recently used if no space left

--- a/lib/rspec-puppet/cache.rb
+++ b/lib/rspec-puppet/cache.rb
@@ -30,7 +30,7 @@ module RSpec::Puppet
 
     def expire!
       # delete one entry (the oldest) when there is no room in cache
-      @cache.delete(@lra.shift) if @cached.size == MAX_ENTRIES
+      @cache.delete(@lra.shift) if @cache.size == MAX_ENTRIES
     end
   end
 end


### PR DESCRIPTION
Before this, when the cache was full, it evicted max-cache-size number of entries from the list of entries.
It would also do eviction after addition.

With a cache size of 3, and using the sequence A, B, C, D, The old version would evict A, B, C. If again B or C was requested, then they would need to be recreated. The old would then have state D. The new will evict only A when it gets D. When it looks up B, it will also move B last, so that the state the is CDB. Next addition E, will the evict C, and state is DBE. If B is again requested, it is moved last and state s DEB.- i.e. the cache caches Most Recently Used.

I am making this change to improve the caching behavior, but also to see if it has effect on the tests that fail on catalog id being different.
