### PR TITLE
(PUP-5743) adapt to new environment name semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.1]
+
+A quick workaround to re-enable testing with the recently released puppet 3.8.5 and the soon to be released puppet 4.3.2. See PUP-5743 for the gritty details. Upgrade to this version if you hit the "undefined method \`resource' for nil:NilClass" error.
+
 ## [2.3.0]
 
 Rspec-puppet now supports testing custom types, `:undef` values in params, structured facts, and checks resource dependencies recursively.

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -9,7 +9,18 @@ module RSpec::Puppet
     end
 
     def environment
-      'rp_env'
+      # unfreeze PUPPETVERSION because of https://github.com/bundler/bundler/issues/3187
+      ver = Gem::Version.new("#{Puppet::PUPPETVERSION}")
+      # Since applying a fix for PUP-5522 (puppet 3.8.5 and 4.3.2) puppet symbolizes environment names
+      # internally. The catalog cache needs to assume that the facts and other args do not change between
+      # runs, so we have to mirror this here. Puppet versions before the change require a string as environment
+      # name, or they fail with "Unsupported data type: 'Symbol' on node xyz"
+      # See https://github.com/rodjek/rspec-puppet/pull/354 and PUP-5743 for discussion of this
+      if (Gem::Version.new('3.8.5') <= ver && ver < Gem::Version.new('4.0.0')) || Gem::Version.new('4.3.2') <= ver
+        :rp_env
+      else
+        'rp_env'
+      end
     end
 
     def load_catalogue(type)

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rspec-puppet'
-  s.version = '2.3.0'
+  s.version = '2.3.1'
   s.homepage = 'https://github.com/rodjek/rspec-puppet/'
   s.summary = 'RSpec tests for your Puppet manifests'
   s.description = 'RSpec tests for your Puppet manifests'


### PR DESCRIPTION
Since applying a fix for PUP-5522 (puppet 3.8.5 and 4.3.2) puppet symbolizes environment names
internally. The catalog cache needs to assume that the facts and other args do not change between
runs, so we have to mirror this here. Puppet versions before the change require a string as environment
name, or they fail with "Unsupported data type: 'Symbol' on node xyz"
See https://github.com/rodjek/rspec-puppet/pull/354 and PUP-5743 for discussion of this