### PR TITLE
Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,49 +4,56 @@ bundler_args: --without development
 
 rvm:
   - 2.1
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 
 sudo: false
 
 env:
-  - PUPPET_VERSION=4.1 COVERAGE=yes
-  - PUPPET_VERSION=2.7
-  - PUPPET_VERSION=3.2
-  - PUPPET_VERSION=3.4
-  - PUPPET_VERSION=3.6
-  - PUPPET_VERSION=3.7
-  - PUPPET_VERSION=3.8
-  - PUPPET_VERSION=4.0
-  - PUPPET_VERSION=4.1
-  - RSPEC_VERSION=2.14
+  - PUPPET_GEM_VERSION='~> 4.3.0' COVERAGE=yes
+  - PUPPET_GEM_VERSION='~> 2.7.0'
+  - PUPPET_GEM_VERSION='~> 3.7.0'
+  - PUPPET_GEM_VERSION='~> 3.8.0'
+  - PUPPET_GEM_VERSION='~> 4.0.0'
+  - PUPPET_GEM_VERSION='~> 4.1.0'
+  - PUPPET_GEM_VERSION='~> 4.2.0'
+  - PUPPET_GEM_VERSION='~> 4.3.0'
+  - PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master'
+  - PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#stable'
+  - PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#3.x'
+  - RSPEC_GEM_VERSION='~> 3.4.0'
 
 matrix:
+  include:
+    # these versions are explicitly needed for ruby 1.8.7 support
+    - rvm: 1.8.7
+      env: RSPEC_GEM_VERSION='= 3.1.7'
+    - rvm: 1.8.7
+      env: RSPEC_GEM_VERSION='~> 2.14.0'
+
   exclude:
+    # newer puppet versions don't run on 1.8.7
     - rvm: 1.8.7
-      env: RSPEC_VERSION=2.14
+      env: PUPPET_GEM_VERSION='~> 4.0.0'
     - rvm: 1.8.7
-      env: PUPPET_VERSION=4.0
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=4.1
+      env: PUPPET_GEM_VERSION='~> 4.1.0'
+    - rvm: 2.1
+      env: PUPPET_GEM_VERSION='~> 4.1.0'
+    # puppet 2.7 doesn't run on newer rubies
     - rvm: 1.9.3
-      env: PUPPET_VERSION=2.7
+      env: PUPPET_GEM_VERSION='~> 2.7.0'
     - rvm: 2.0.0
-      env: PUPPET_VERSION=2.7
+      env: PUPPET_GEM_VERSION='~> 2.7.0'
     - rvm: 2.1
-      env: PUPPET_VERSION=2.7
-    - rvm: 2.1
-      env: PUPPET_VERSION=3.2
+      env: PUPPET_GEM_VERSION='~> 2.7.0'
     # run Coveralls exactly once
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=4.1 COVERAGE=yes
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.1 COVERAGE=yes
+      env: PUPPET_GEM_VERSION='~> 4.3.0' COVERAGE=yes
     - rvm: 2.0.0
-      env: PUPPET_VERSION=4.1 COVERAGE=yes
-    - rvm: 2.1
-      env: PUPPET_VERSION=4.1
+      env: PUPPET_GEM_VERSION='~> 4.3.0' COVERAGE=yes
+
+  allowed_failures:
+    - env: PUPPET_GEM_VERSION='git:https://github.com/puppetlabs/puppet.git#master'
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,20 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}.0" : ['~> 4.0']
-rspecversion = ENV.key?('RSPEC_VERSION') ? "= #{ENV['RSPEC_VERSION']}" : ['~> 2.0']
+def location_for(place, fake_version = nil)
+  if place =~ /^((?:git|https?)[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
 
 gemspec
 
 gem 'rake'
-gem 'rspec', rspecversion
-gem 'rspec-core', rspecversion
-gem 'puppet', puppetversion
+gem 'rspec', *location_for(ENV['RSPEC_GEM_VERSION'] || '~> 3.0')
+gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'] || '~> 4.0')
 
 gem 'pry', :group => :development
 


### PR DESCRIPTION
On yesterday's release I missed testing against puppet 4.3.2, leading to the
inevitable downstream failures. This changes the travis CI matrix to cover the
latest puppet releases. Additionally I've added entries and infrastructure to
run the tests against a few branches from puppet's repo.