### PR TITLE
Code Coverage Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,16 @@ This checks which Puppet resources have been explicitly checked as part
 of the current test run and outputs both a coverage percentage and a
 list of untouched resources.
 
+A desired code coverage level can be provided. If this level is not achieved, a test failure will be raised.  This can be used with a CI service, such as Jenkins or Bamboo, to enforce code coverage.  The following example requires the code coverage to be at least 95%.
+
+```ruby
+RSpec.configure do |c|
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!(95)
+  end
+end
+```
+
 ## Related projects
 
 * [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec_helper): shared spec helpers to setup puppet

--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -48,7 +48,7 @@ module RSpec::Puppet
       end
     end
 
-    def report!
+    def report!(coverage_desired = nil)
       report = results
       puts <<-EOH.gsub(/^ {8}/, '')
 
@@ -70,6 +70,24 @@ module RSpec::Puppet
             end.sort.join("\n")
           }
         EOH
+        if coverage_desired
+          coverage_test(coverage_desired, report[:coverage])
+        end
+      end
+    end
+
+    def coverage_test(coverage_desired, coverage_actual)
+      if coverage_desired.is_a?(Numeric) && coverage_desired.to_f <= 100.00 && coverage_desired.to_f >= 0.0
+        coverage_test = RSpec.describe("Code coverage.")
+        coverage_results = coverage_test.example("Must be at least #{coverage_desired}% of code coverage") {
+          expect( coverage_actual.to_f ).to be >= coverage_desired.to_f
+        }
+        coverage_test.run
+        passed = coverage_results.execution_result.status == :passed
+
+        RSpec.configuration.reporter.example_failed coverage_results unless passed
+      else
+        puts "The desired coverage must be 0 <= x <= 100, not '#{coverage_desired.inspect}'"
       end
     end
 


### PR DESCRIPTION
This update allows the user to provide a minimum code coverage level
that must be achieved.  A failure will result in a test failure.