### PR TITLE
Enable nested hashes in params

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -123,9 +123,16 @@ module RSpec::Puppet
     end
 
     def param_str
-      params.keys.map do |r|
-        param_val = params[r]
-        param_val_str = if param_val == :undef
+      param_str_from_hash(params)
+    end
+
+    def param_str_from_hash(params_hash)
+      params_hash.keys.map do |r|
+        param_val = params_hash[r]
+        param_val_str = case param_val 
+                        when Hash
+                          "{ #{param_str_from_hash(param_val)} }"
+                        when :undef
                           'undef'  # verbatim undef keyword
                         else
                           escape_special_chars(param_val.inspect)


### PR DESCRIPTION
Currently, it isn't possible to nest a hash within a param, so something like this:

    let(:params) do
      {
        description: 'A job with a masked password',
        masked_passwords: { 
          db_password: 'abcdefg'
        }
      }
    end

fails with an error along these lines:

    Puppet::ParseErrorWithIssue:
      Could not parse for environment rp_env: Syntax error at ':' at line 1:117
This change enables nested hashes to be parsed correctly.

(See https://github.com/rodjek/rspec-puppet/pull/382 for slightly more background)