### PR TITLE
add mocks to allow cross os testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,12 @@ end
 
 gemspec
 
-gem 'rake'
+if RUBY_VERSION < '1.9.3'
+  gem 'rake', '< 11'
+  gem 'json_pure', '< 2.0'
+else
+  gem 'rake', :require => false
+end
 gem 'rspec', *location_for(ENV['RSPEC_GEM_VERSION'] || '~> 3.0')
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'] || '~> 4.0')
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,12 +12,7 @@ end
 
 gemspec
 
-if RUBY_VERSION < '1.9.3'
-  gem 'rake', '< 11'
-  gem 'json_pure', '< 2.0'
-else
-  gem 'rake', :require => false
-end
+gem 'rake'
 gem 'rspec', *location_for(ENV['RSPEC_GEM_VERSION'] || '~> 3.0')
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'] || '~> 4.0')
 

--- a/lib/rspec-puppet/spec_helper.rb
+++ b/lib/rspec-puppet/spec_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |c|
       require 'puppet/provider/confine/exists'
       Puppet::Provider::Confine::Exists.any_instance.stubs(:which => '')
     else
-      # ONLY WORKING WITH PUPPET > 3.2 !!
+      # ONLY WORKING WITH PUPPET >= 3.2 !!
       require 'puppet/confine/exists'
       Puppet::Confine::Exists.any_instance.stubs(:which => '')
     end

--- a/lib/rspec-puppet/spec_helper.rb
+++ b/lib/rspec-puppet/spec_helper.rb
@@ -6,4 +6,19 @@ RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
   c.environmentpath = File.join(Dir.pwd, 'spec')
+  c.before(:each) do
+    # work around https://tickets.puppetlabs.com/browse/PUP-1547
+    # ensure that there's at least one provider available by emulating that any
+    if Puppet::version < '3.2'
+      # ONLY WORKING WITH PUPPET < 3.2 !!
+      require 'puppet/provider/confine/exists'
+      Puppet::Provider::Confine::Exists.any_instance.stubs(:which => '')
+    else
+      # ONLY WORKING WITH PUPPET > 3.2 !!
+      require 'puppet/confine/exists'
+      Puppet::Confine::Exists.any_instance.stubs(:which => '')
+    end
+    # avoid "Only root can execute commands as other users"
+    Puppet.features.stubs(:root? => true)
+  end
 end


### PR DESCRIPTION
taken from
https://github.com/maestrodev/maestro-puppet-example/blob/master/spec/spec_helper.rb

work around https://tickets.puppetlabs.com/browse/PUP-1547
Ticket mentions fixed in 3.6.0 but rspec testing e.g. on OSX still
throws errors for package ensure set to latest and user with managehome
attribute and exec with user set to not root

should this be configurable?