### PR TITLE
(ORCH-1518) Introduce app_management testing support

### DIFF
--- a/lib/rspec-puppet/example.rb
+++ b/lib/rspec-puppet/example.rb
@@ -5,6 +5,7 @@ require 'rspec-puppet/example/function_example_group'
 require 'rspec-puppet/example/host_example_group'
 require 'rspec-puppet/example/type_example_group'
 require 'rspec-puppet/example/provider_example_group'
+require 'rspec-puppet/example/application_example_group'
 
 RSpec::configure do |c|
 
@@ -31,6 +32,9 @@ RSpec::configure do |c|
     c.include RSpec::Puppet::ProviderExampleGroup, :type => :provider, :example_group => {
       :file_path => c.escaped_path(%w[spec providers])
     }
+    c.include RSpec::Puppet::ApplicationExampleGroup, :type => :application, :example_group => {
+      :file_path => c.escaped_path(%w[spec applications])
+    }
   else
     c.include RSpec::Puppet::DefineExampleGroup, :type => :define, :file_path => c.escaped_path(%w[spec defines])
     c.include RSpec::Puppet::ClassExampleGroup, :type => :class, :file_path => c.escaped_path(%w[spec classes])
@@ -38,6 +42,7 @@ RSpec::configure do |c|
     c.include RSpec::Puppet::HostExampleGroup, :type => :host, :file_path => c.escaped_path(%w[spec hosts])
     c.include RSpec::Puppet::TypeExampleGroup, :type => :type, :file_path => c.escaped_path(%w[spec types])
     c.include RSpec::Puppet::ProviderExampleGroup, :type => :provider, :file_path => c.escaped_path(%w[spec providers])
+    c.include RSpec::Puppet::ApplicationExampleGroup, :type => :application, :file_path => c.escaped_path(%w[spec applications])
   end
 
   # Hook for each example group type to remove any caches or instance variables, since they will remain

--- a/lib/rspec-puppet/example/application_example_group.rb
+++ b/lib/rspec-puppet/example/application_example_group.rb
@@ -1,0 +1,19 @@
+module RSpec::Puppet
+  # This module provides support for the application type
+  module ApplicationExampleGroup
+    include RSpec::Puppet::ManifestMatchers
+    include RSpec::Puppet::Support
+
+    def catalogue
+      @catalogue ||= load_catalogue(:application)
+    end
+
+    def exported_resources
+      lambda { load_catalogue(:application, true) }
+    end
+
+    def rspec_puppet_cleanup
+      @catalogue = nil
+    end
+  end
+end

--- a/lib/rspec-puppet/raw_string.rb
+++ b/lib/rspec-puppet/raw_string.rb
@@ -1,0 +1,16 @@
+module RSpec::Puppet
+  # A raw string object, that is used by helpers to allow consumers to return non-quoted strings
+  # as part of their params section.
+  class RawString
+    # Create a new RawString object
+    # @param [String] value string to wrap
+    def initialize(value)
+      @value = value
+    end
+
+    # @return [String] raw string
+    def inspect
+      @value
+    end
+  end
+end

--- a/spec/applications/orch_app_spec.rb
+++ b/spec/applications/orch_app_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'orch_app', :if => Puppet.version.to_f >= 4.3 do
+  let(:node) { 'my_node' }
+  let(:title) { 'my_awesome_app' }
+  let(:params) do
+    {
+      :nodes => {
+        ref('Node', node) => ref('Orch_app::Db', title),
+      },
+      :mystring => 'foobar',
+    }
+  end
+
+  it { should compile }
+  it { should contain_orch_app(title) }
+  it { should contain_orch_app__db(title) }
+end

--- a/spec/fixtures/modules/orch_app/manifests/db.pp
+++ b/spec/fixtures/modules/orch_app/manifests/db.pp
@@ -1,0 +1,3 @@
+define orch_app::db(
+) {
+}

--- a/spec/fixtures/modules/orch_app/manifests/init.pp
+++ b/spec/fixtures/modules/orch_app/manifests/init.pp
@@ -1,0 +1,6 @@
+application orch_app (
+  String $mystring,
+) {
+  orch_app::db { $name:
+  }
+}

--- a/spec/raw_string_spec.rb
+++ b/spec/raw_string_spec.rb
@@ -1,0 +1,9 @@
+require 'rspec-puppet/raw_string'
+
+describe RSpec::Puppet::RawString do
+  describe '#inspect' do
+    it 'returns the raw string when doing an inspect' do
+      expect(RSpec::Puppet::RawString.new('my_raw_string').inspect).to eq('my_raw_string')
+    end
+  end
+end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -26,4 +26,10 @@ describe RSpec::Puppet::Support do
       expect($LOAD_PATH).to include(dirb)
     end
   end
+
+  describe "#ref" do
+    it 'should return a new RawString with the type/title format' do
+      expect(subject.ref('Package','tomcat').inspect).to eq("Package['tomcat']")
+    end
+  end
 end


### PR DESCRIPTION
    This patch adds support the `app_management` feature added to Puppet in 4.3.

    It provides a new type `application` that can now be created much like a class
    or resource. It also enables the `app_management` setting automatically when
    the version of Puppet provided has this feature.

    To assist with passing resource references as required by application node mappings,
    this patch introduces the new `ref` helper to allow test writers to provide
    resource refs that appear as raw strings (instead of being quoted like normal strings).

    All this new support is documented in the README.md, and tests have been added
    to provide basic coverage for this new work.

    Signed-off-by: Ken Barber <ken@bob.sh>