### PR TITLE
(MODULES-3737) Allow testing internal puppet 4 functions

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -13,10 +13,17 @@ module RSpec::Puppet
         @overrides = overrides
       end
 
-      def call(*args)
+      # This method is used by the `run` matcher to trigger the function execution, and provides a uniform interface across all puppet versions.
+      def execute(*args)
         Puppet.override(@overrides, "rspec-test scope") do
           @func.call(@overrides[:global_scope], *args)
         end
+      end
+
+      # compatibility alias for existing tests
+      def call(scope, *args)
+        RSpec.deprecate("subject.call", :replacement => "is_expected.to run.with().and_raise_error(), or execute()")
+        execute(*args)
       end
     end
 
@@ -28,11 +35,22 @@ module RSpec::Puppet
         @func = func
       end
 
-      def call(*args)
+      # This method is used by the `run` matcher to trigger the function execution, and provides a uniform interface across all puppet versions.
+      def execute(*args)
         if args.nil?
           @func.call
         else
           @func.call(args)
+        end
+      end
+
+      # This method was formerly used by the `run` matcher to trigger the function execution, and provides puppet versions dependant interface.
+      def call(*args)
+        RSpec.deprecate("subject.call", :replacement => "is_expected.to run.with().and_raise_error(), or execute()")
+        if args.nil?
+          @func.call
+        else
+          @func.call(*args)
         end
       end
     end

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -4,27 +4,69 @@ module RSpec::Puppet
     include RSpec::Puppet::ManifestMatchers
     include RSpec::Puppet::Support
 
+    class V4FunctionWrapper
+      attr_reader :func, :func_name
+
+      def initialize(name, func, overrides)
+        @func_name = name
+        @func = func
+        @overrides = overrides
+      end
+
+      def call(*args)
+        Puppet.override(@overrides, "rspec-test scope") do
+          @func.call(@overrides[:global_scope], *args)
+        end
+      end
+    end
+
+    class V3FunctionWrapper
+      attr_accessor :func_name
+
+      def initialize(name, func)
+        @func_name = name
+        @func = func
+      end
+
+      def call(*args)
+        if args.nil?
+          @func.call
+        else
+          @func.call(args)
+        end
+      end
+    end
+
+    # (at least) rspec 3.5 doesn't seem to memoize `subject` when called from
+    # a before(:each) hook, so we need to memoize it ourselves.
     def subject
+      @subject ||= find_function
+    end
+
+    def find_function
       function_name = self.class.top_level_description.downcase
 
       with_vardir do
+        env = adapter.current_environment
+
         if Puppet.version.to_f >= 4.0
-          env = adapter.current_environment
-          loader = Puppet::Pops::Loaders.new(env)
-          func = loader.private_environment_loader.load(:function, function_name)
-          return func if func
+          context_overrides = compiler.context_overrides
+          func = nil
+          Puppet.override(context_overrides, "rspec-test scope") do
+            loader = Puppet::Pops::Loaders.new(env)
+            func = V4FunctionWrapper.new(function_name, loader.private_environment_loader.load(:function, function_name), context_overrides)
+            @scope = context_overrides[:global_scope]
+          end
+
+          return func if func.func
         end
 
-        # Return the method instance for the function.  This can be used with
-        # method.call
-        if env
-          return nil unless Puppet::Parser::Functions.function(function_name, env)
+        if Puppet::Parser::Functions.function(function_name)
+          V3FunctionWrapper.new(function_name, scope.method("function_#{function_name}".intern))
         else
-          return nil unless Puppet::Parser::Functions.function(function_name)
+          nil
         end
       end
-
-      scope.method("function_#{function_name}".intern)
     end
 
     def scope
@@ -36,6 +78,7 @@ module RSpec::Puppet
     end
 
     def rspec_puppet_cleanup
+      @subject = nil
       @catalogue = nil
       @compiler = nil
       @scope = nil
@@ -71,7 +114,9 @@ module RSpec::Puppet
     end
 
     def build_scope(compiler, node_name)
-      if Puppet.version =~ /^2\.[67]/
+      if Puppet.version.to_f >= 4.0
+        return compiler.context_overrides[:global_scope]
+      elsif Puppet.version =~ /^2\.[67]/
         # loadall should only be necessary prior to 3.x
         # Please note, loadall needs to happen first when creating a scope, otherwise
         # you might receive undefined method `function_*' errors

--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -3,23 +3,11 @@ module RSpec::Puppet
     class Run
       def matches?(func_obj)
         @func_obj = func_obj
-        if @params
-          if Puppet.version.to_f >= 4.0 and ! @func_obj.respond_to?(:receiver)
-            @func = lambda { func_obj.call({}, *@params) }
-          else
-            @func = lambda { func_obj.call(@params) }
-          end
-        else
-          if Puppet.version.to_f >= 4.0 and ! @func_obj.respond_to?(:receiver)
-            @func = lambda { func_obj.call({}) }
-          else
-            @func = lambda { func_obj.call }
-          end
-        end
 
         @has_returned = false
         begin
-          @actual_return = @func.call
+          # `*nil` does not evaluate to "no params" on ruby 1.8 :-(
+          @actual_return = @params.nil? ? @func_obj.call : @func_obj.call(*@params)
           @has_returned = true
         rescue Exception => e
           @actual_error = e
@@ -113,11 +101,7 @@ module RSpec::Puppet
 
       private
       def func_name
-        if Puppet.version.to_f >= 4.0 and ! @func_obj.respond_to?(:receiver)
-          @func_name ||= @func_obj.class.name
-        else
-          @func_name ||= @func_obj.name.to_s.gsub(/^function_/, '')
-        end
+        @func_obj.func_name
       end
 
       def func_params
@@ -129,9 +113,9 @@ module RSpec::Puppet
           ''
         elsif @actual_error
           if @has_expected_return
-            " instead of raising #{@actual_error.class.inspect}(#{@actual_error})"
+            " instead of raising #{@actual_error.class.inspect}(#{@actual_error})\n#{@actual_error.backtrace.join("\n")}"
           else
-            " instead of #{@actual_error.class.inspect}(#{@actual_error})"
+            " instead of #{@actual_error.class.inspect}(#{@actual_error})\n#{@actual_error.backtrace.join("\n")}"
           end
         else # function has returned
           if @has_expected_error

--- a/lib/rspec-puppet/matchers/run.rb
+++ b/lib/rspec-puppet/matchers/run.rb
@@ -7,7 +7,7 @@ module RSpec::Puppet
         @has_returned = false
         begin
           # `*nil` does not evaluate to "no params" on ruby 1.8 :-(
-          @actual_return = @params.nil? ? @func_obj.call : @func_obj.call(*@params)
+          @actual_return = @params.nil? ? @func_obj.execute : @func_obj.execute(*@params)
           @has_returned = true
         rescue Exception => e
           @actual_error = e

--- a/spec/functions/test_function_spec.rb
+++ b/spec/functions/test_function_spec.rb
@@ -2,5 +2,5 @@ require 'spec_helper'
 
 describe 'test_function', :if => Puppet.version.to_f >= 4.0 do
   # Verify that we can load functions from modules
-  it { should run.with_params('foo').and_return(/value is foo/) }
+  it { is_expected.to run.with_params('foo').and_return(/value is foo/) }
 end

--- a/spec/unit/example/function_example_group_spec.rb
+++ b/spec/unit/example/function_example_group_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.0
+  describe RSpec::Puppet::FunctionExampleGroup::V4FunctionWrapper do
+    let(:name) { 'test_function' }
+    let(:func) { double('func') }
+    let(:global_scope) { double('global_scope') }
+    let(:overrides) { { :global_scope => global_scope } }
+
+    describe 'when calling with params' do
+      subject { described_class.new(name, func, overrides) }
+      it do
+        expect(func).to receive(:call).with(global_scope, 1, 2).once
+        subject.call({}, 1, 2)
+      end
+    end
+
+    describe 'when executing with params' do
+      subject { described_class.new(name, func, overrides) }
+      it do
+        expect(func).to receive(:call).with(global_scope, 1, 2).once
+        subject.execute(1, 2)
+      end
+    end
+  end
+end
+
+describe RSpec::Puppet::FunctionExampleGroup::V3FunctionWrapper do
+  let(:name) { 'test_function' }
+  let(:func) { double('func') }
+
+  describe 'when calling with params' do
+    subject { described_class.new(name, func) }
+    it do
+      expect(func).to receive(:call).with([1, 2]).once
+      subject.call([1, 2])
+    end
+  end
+
+  describe 'when executing with params' do
+    subject { described_class.new(name, func) }
+    it do
+      expect(func).to receive(:call).with([1, 2]).once
+      subject.execute(1, 2)
+    end
+  end
+end

--- a/spec/unit/matchers/run_spec.rb
+++ b/spec/unit/matchers/run_spec.rb
@@ -1,85 +1,96 @@
 require 'spec_helper'
 
 describe RSpec::Puppet::FunctionMatchers::Run do
-  it 'should call the lambda with no params' do
-    received_params = nil
-    subject.matches?(lambda { |*params| received_params = params })
-    expect(received_params).to eq([])
+  let (:wrapper) { double("function wrapper") }
+
+  before :each do
+    expect(wrapper).to receive(:call).never
   end
 
-  it 'should not match a lambda that raises an error' do
-    expect(subject.matches?(lambda { |params| raise StandardError, 'Forced Error' })).to be false
+  it 'should call the wrapper with no params' do
+    expect(wrapper).to receive(:execute).with(no_args).once
+    expect(subject.matches?(wrapper)).to be true
   end
 
-  [ [], [true], [false], [''], ['string'], [nil], [0], [1.1], [[]], ['one', 'two'], [{}], [{ 'key' => 'value' }], [:undef] ].each do |supplied_params|
+  it 'should not match a wrapper that raises an error' do
+    expect(wrapper).to receive(:execute).and_raise(StandardError, 'Forced Error').once
+    expect(subject.matches?(wrapper)).to be false
+  end
+
+  [ [true], [false], [''], ['string'], [nil], [0], [1.1], [[]], ['one', 'two'], [{}], [{ 'key' => 'value' }], [:undef] ].each do |supplied_params|
     context "with_params(#{supplied_params.collect { |p| p.inspect }.join(', ')})" do
       before(:each) { subject.with_params(*supplied_params) }
 
-      it 'should call the lambda with the supplied params' do
-        received_params = nil
-        subject.matches?(lambda { |*params| received_params = params })
-        expect(received_params).to eq(supplied_params)
+      it 'should call the wrapper with the supplied params' do
+        expect(wrapper).to receive(:execute).with(*supplied_params).once
+        expect(subject.matches?(wrapper)).to be true
       end
 
-      it 'should not match a lambda that raises an error' do
-        expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
+      it 'should not match a wrapper that raises an error' do
+        expect(wrapper).to receive(:execute).and_raise(StandardError, 'Forced Error').once
+        expect(subject.matches?(wrapper)).to be false
       end
+    end
 
-      [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |expected_return|
-        context "and_return(#{expected_return.inspect})" do
-          before(:each) { subject.and_return(expected_return) }
+    [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |expected_return|
+      context "and_return(#{expected_return.inspect})" do
+        before(:each) { subject.and_return(expected_return) }
 
-          it 'should match a lambda that does return the requested value' do
-            expect(subject.matches?(lambda { |*params| expected_return })).to be true
-          end
+        it 'should match a wrapper that does return the requested value' do
+          expect(wrapper).to receive(:execute).and_return(expected_return).once
+          expect(subject.matches?(wrapper)).to be true
+        end
 
-          it 'should not match a lambda that does return a different value' do
-            expect(subject.matches?(lambda { |*params| !expected_return })).to be false
-          end
-
-          it 'should not match a lambda that raises an error' do
-            expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
-          end
+        it 'should not match a wrapper that does return a different value' do
+          expect(wrapper).to receive(:execute).and_return(!expected_return).once
+          expect(subject.matches?(wrapper)).to be false
         end
       end
 
       context "and_raise_error(ArgumentError)" do
         before(:each) { subject.and_raise_error(ArgumentError) }
 
-        it 'should match a lambda that raises ArgumentError' do
-          expect(subject.matches?(lambda { |*params|  raise ArgumentError, 'Forced Error' })).to be true
+        it 'should match a wrapper that raises ArgumentError' do
+          expect(wrapper).to receive(:execute).and_raise(ArgumentError, 'Forced Error').once
+          expect(subject.matches?(wrapper)).to be true
         end
 
         [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |value|
-          it "should not match a lambda that returns #{value.inspect}" do
-            expect(subject.matches?(lambda { |*params| value })).to be false
+          it "should not match a wrapper that returns #{value.inspect}" do
+            expect(wrapper).to receive(:execute).and_return(value).once
+            expect(subject.matches?(wrapper)).to be false
           end
         end
 
-        it 'should not match a lambda that raises a different error' do
-          expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
+        it 'should not match a wrapper that raises a different error' do
+          expect(wrapper).to receive(:execute).and_raise(StandardError, 'Forced Error').once
+          expect(subject.matches?(wrapper)).to be false
         end
       end
 
       context "and_raise_error(ArgumentError, /message/)" do
         before(:each) { subject.and_raise_error(ArgumentError, /message/) }
 
-        it 'should match a lambda that raises ArgumentError("with matching message")' do
-          expect(subject.matches?(lambda { |*params| raise ArgumentError, 'with matching message' })).to be true
+        it 'should match a wrapper that raises ArgumentError("with matching message")' do
+          expect(wrapper).to receive(:execute).and_raise(ArgumentError, 'with matching message').once
+          expect(subject.matches?(wrapper)).to be true
         end
 
-        it 'should not match a lambda that raises a different ArgumentError' do
-          expect(subject.matches?(lambda { |*params| raise ArgumentError, 'Forced Error' })).to be false
+        it 'should not match a wrapper that raises a different ArgumentError' do
+          expect(wrapper).to receive(:execute).and_raise(ArgumentError, 'Forced Error').once
+          expect(subject.matches?(wrapper)).to be false
         end
 
         [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |value|
-          it "should not match a lambda that returns #{value.inspect}" do
-            expect(subject.matches?(lambda { |*params| value })).to be false
+          it "should not match a wrapper that returns #{value.inspect}" do
+            expect(wrapper).to receive(:execute).and_return(value).once
+            expect(subject.matches?(wrapper)).to be false
           end
         end
 
-        it 'should not match a lambda that raises a different error' do
-          expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
+        it 'should not match a wrapper that raises a different error' do
+          expect(wrapper).to receive(:execute).and_raise(StandardError, 'Forced Error').once
+          expect(subject.matches?(wrapper)).to be false
         end
       end
     end

--- a/spec/unit/matchers/run_spec.rb
+++ b/spec/unit/matchers/run_spec.rb
@@ -3,17 +3,12 @@ require 'spec_helper'
 describe RSpec::Puppet::FunctionMatchers::Run do
   it 'should call the lambda with no params' do
     received_params = nil
-    if Puppet.version.to_f >= 4.0
-      subject.matches?(lambda { |env, *params| received_params = params })
-      expect(received_params).to eq([])
-    else
-      subject.matches?(lambda { |params| received_params = params })
-      expect(received_params).to be_nil
-    end
+    subject.matches?(lambda { |*params| received_params = params })
+    expect(received_params).to eq([])
   end
 
   it 'should not match a lambda that raises an error' do
-    expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be false
+    expect(subject.matches?(lambda { |params| raise StandardError, 'Forced Error' })).to be false
   end
 
   [ [], [true], [false], [''], ['string'], [nil], [0], [1.1], [[]], ['one', 'two'], [{}], [{ 'key' => 'value' }], [:undef] ].each do |supplied_params|
@@ -22,16 +17,12 @@ describe RSpec::Puppet::FunctionMatchers::Run do
 
       it 'should call the lambda with the supplied params' do
         received_params = nil
-        if Puppet.version.to_f >= 4.0
-          subject.matches?(lambda { |env, *params| received_params = params })
-        else
-          subject.matches?(lambda { |params| received_params = params })
-        end
+        subject.matches?(lambda { |*params| received_params = params })
         expect(received_params).to eq(supplied_params)
       end
 
       it 'should not match a lambda that raises an error' do
-        expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be false
+        expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
       end
 
       [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |expected_return|
@@ -39,15 +30,15 @@ describe RSpec::Puppet::FunctionMatchers::Run do
           before(:each) { subject.and_return(expected_return) }
 
           it 'should match a lambda that does return the requested value' do
-            expect(subject.matches?(lambda { |env, *params| expected_return })).to be true
+            expect(subject.matches?(lambda { |*params| expected_return })).to be true
           end
 
           it 'should not match a lambda that does return a different value' do
-            expect(subject.matches?(lambda { |env, *params| !expected_return })).to be false
+            expect(subject.matches?(lambda { |*params| !expected_return })).to be false
           end
 
           it 'should not match a lambda that raises an error' do
-            expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be false
+            expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
           end
         end
       end
@@ -56,17 +47,17 @@ describe RSpec::Puppet::FunctionMatchers::Run do
         before(:each) { subject.and_raise_error(ArgumentError) }
 
         it 'should match a lambda that raises ArgumentError' do
-          expect(subject.matches?(lambda { |env, *params| raise ArgumentError, 'Forced Error' })).to be true
+          expect(subject.matches?(lambda { |*params|  raise ArgumentError, 'Forced Error' })).to be true
         end
 
         [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |value|
           it "should not match a lambda that returns #{value.inspect}" do
-            expect(subject.matches?(lambda { |env, *params| value })).to be false
+            expect(subject.matches?(lambda { |*params| value })).to be false
           end
         end
 
         it 'should not match a lambda that raises a different error' do
-          expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be false
+          expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
         end
       end
 
@@ -74,21 +65,21 @@ describe RSpec::Puppet::FunctionMatchers::Run do
         before(:each) { subject.and_raise_error(ArgumentError, /message/) }
 
         it 'should match a lambda that raises ArgumentError("with matching message")' do
-          expect(subject.matches?(lambda { |env, *params| raise ArgumentError, 'with matching message' })).to be true
+          expect(subject.matches?(lambda { |*params| raise ArgumentError, 'with matching message' })).to be true
         end
 
         it 'should not match a lambda that raises a different ArgumentError' do
-          expect(subject.matches?(lambda { |env, *params| raise ArgumentError, 'Forced Error' })).to be false
+          expect(subject.matches?(lambda { |*params| raise ArgumentError, 'Forced Error' })).to be false
         end
 
         [ true, false, '', 'string', nil, 0, 1.1, [], {}, :undef ].each do |value|
           it "should not match a lambda that returns #{value.inspect}" do
-            expect(subject.matches?(lambda { |env, *params| value })).to be false
+            expect(subject.matches?(lambda { |*params| value })).to be false
           end
         end
 
         it 'should not match a lambda that raises a different error' do
-          expect(subject.matches?(lambda { |env, *params| raise StandardError, 'Forced Error' })).to be false
+          expect(subject.matches?(lambda { |*params| raise StandardError, 'Forced Error' })).to be false
         end
       end
     end


### PR DESCRIPTION
Some puppet 4 functions require access to the scope, which needs to be
provided through the loader.

Since the loader override needs to be active during function evaluation,
this also adds a wrapper for that func, and changes so that the func name
is displayed properly.

To reduce complexity of the rest of the code, a similar wrapper is
introduced for puppet 3. This makes the rest of the code simpler.