### PR TITLE
Fix naming of test_api specs so they run

### DIFF
--- a/spec/classes/test_api_spec.rb
+++ b/spec/classes/test_api_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 describe 'test::bare_class' do
   describe 'rspec group' do
     it 'should have a catalogue method' do
-      catalogue.should be_a(Puppet::Resource::Catalog)
+      expect(catalogue).to be_a(Puppet::Resource::Catalog)
     end
 
     it 'subject should return a catalogue' do
-      subject.should be_a(Puppet::Resource::Catalog)
+      expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
 
     describe 'derivative group' do
       subject { catalogue.resource('Notify', 'foo') }
 
       it 'can redefine subject' do
-        subject.should be_a(Puppet::Resource)
+        expect(subject).to be_a(Puppet::Resource)
       end
     end
   end

--- a/spec/defines/test_api_spec.rb
+++ b/spec/defines/test_api_spec.rb
@@ -6,11 +6,11 @@ describe 'sysctl' do
 
   describe 'rspec group' do
     it 'should have a catalogue method' do
-      catalogue.should be_a(Puppet::Resource::Catalog)
+      expect(catalogue).to be_a(Puppet::Resource::Catalog)
     end
 
     it 'subject should return a catalogue' do
-      subject.should be_a(Puppet::Resource::Catalog)
+      expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
   end
 end

--- a/spec/hosts/test_api_spec.rb
+++ b/spec/hosts/test_api_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe 'foo.example.com' do
   describe 'rspec group' do
     it 'should have a catalogue method' do
-      catalogue.should be_a(Puppet::Resource::Catalog)
+      expect(catalogue).to be_a(Puppet::Resource::Catalog)
     end
 
     it 'subject should return a catalogue' do
-      subject.should be_a(Puppet::Resource::Catalog)
+      expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
   end
 end


### PR DESCRIPTION
Incorrectly named ever since they were added 7dddebd, updated to take
into account the change of `subject` in 34220fc and rspec should/expect
style changes.
