### PR TITLE
Handle Ruby Symbols in nested Hashes/Arrays when testing Puppet params

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -153,10 +153,17 @@ module RSpec::Puppet
           "#{str_from_value(k)} => #{str_from_value(v)}"
         end.join(", ")
         "{ #{kvs} }"
+      when Array
+        vals = value.map do |v|
+          str_from_value(v)
+        end.join(", ")
+        "[ #{vals} ]"
       when :default
         'default'  # verbatim default keyword
       when :undef
         'undef'  # verbatim undef keyword
+      when Symbol
+        str_from_value(value.to_s)
       else
         escape_special_chars(value.inspect)
       end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -32,4 +32,32 @@ describe RSpec::Puppet::Support do
       expect(subject.ref('Package','tomcat').inspect).to eq("Package['tomcat']")
     end
   end
+
+  describe '#str_from_value' do
+    it "should quote strings" do
+      expect(subject.str_from_value('a string')).to eq('"a string"')
+    end
+    it "should not quote numbers" do
+      expect(subject.str_from_value(100)).to eq('100')
+      expect(subject.str_from_value(-42)).to eq('-42')
+      expect(subject.str_from_value(3.14)).to eq('3.14')
+    end
+    it "should use literal 'default' when receiving :default" do
+      expect(subject.str_from_value(:default)).to eq('default')
+    end
+    it "should use literal 'undef' when receiving :undef" do
+      expect(subject.str_from_value(:undef)).to eq('undef')
+    end
+    it "should convert Symbols to Strings" do
+      expect(subject.str_from_value(:a_symbol)).to eq('"a_symbol"')
+    end
+    it "should handle Arrays recursively" do
+      expect(subject.str_from_value([1,2,3])).to eq('[ 1, 2, 3 ]')
+    end
+    it "should handle Hashes recursively" do
+      expect(subject.str_from_value({:k1=>'v1'})).to eq('{ "k1" => "v1" }')
+      expect(subject.str_from_value({'k2'=>'v2'})).to eq('{ "k2" => "v2" }')
+      expect(subject.str_from_value({k3: 'v3'})).to eq('{ "k3" => "v3" }')
+    end
+  end
 end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -57,9 +57,6 @@ describe RSpec::Puppet::Support do
     it "should handle Hashes recursively" do
       expect(subject.str_from_value({:k1=>'v1'})).to eq('{ "k1" => "v1" }')
       expect(subject.str_from_value({'k2'=>'v2'})).to eq('{ "k2" => "v2" }')
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9') # Syntax not valid in Ruby 1.8.7
-        expect(subject.str_from_value({k3: 'v3'})).to eq('{ "k3" => "v3" }')
-      end
     end
   end
 end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -57,7 +57,7 @@ describe RSpec::Puppet::Support do
     it "should handle Hashes recursively" do
       expect(subject.str_from_value({:k1=>'v1'})).to eq('{ "k1" => "v1" }')
       expect(subject.str_from_value({'k2'=>'v2'})).to eq('{ "k2" => "v2" }')
-      if RUBY_VERSION >= Gem::Version.new('1.9') # Syntax not valid in Ruby 1.8.7
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9') # Syntax not valid in Ruby 1.8.7
         expect(subject.str_from_value({k3: 'v3'})).to eq('{ "k3" => "v3" }')
       end
     end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -57,7 +57,9 @@ describe RSpec::Puppet::Support do
     it "should handle Hashes recursively" do
       expect(subject.str_from_value({:k1=>'v1'})).to eq('{ "k1" => "v1" }')
       expect(subject.str_from_value({'k2'=>'v2'})).to eq('{ "k2" => "v2" }')
-      expect(subject.str_from_value({k3: 'v3'})).to eq('{ "k3" => "v3" }')
+      if RUBY_VERSION >= Gem::Version.new('1.9') # Syntax not valid in Ruby 1.8.7
+        expect(subject.str_from_value({k3: 'v3'})).to eq('{ "k3" => "v3" }')
+      end
     end
   end
 end


### PR DESCRIPTION
When testing defines and passing nested hashes to params while using Symbols for keys, rspec-puppet leaves the ':' character in place when setting up the example. This causes puppet to complain about syntax errors on line 3, expecting '}' instead of ':'. This PR converts symbols to strings before substituting them as well as handles arrays just like hashes are already handled.

specs for RSpec::Puppet::Support#str_from_value also added.