### PR TITLE
Add full support for the trusted facts hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,31 @@ However, if you want to specify it in each example, you can do so
 let(:module_path) { '/path/to/your/module/dir' }
 ```
 
+#### Specifying trusted facts
+
+When testing with Puppet >= 4.3 the trusted facts hash will have the standard trusted fact keys
+(certname, domain, and hostname) populated based on the node name (as set with `:node`).
+
+By default, the test environment contains no custom trusted facts (as usually obtained
+from certificate extensions) and found in the `extensions` key. If you need to test against
+specific custom certificate extensions you can set those with a hash. The hash will then
+be available in `$trusted['extensions']`
+
+```ruby
+let(:trusted_facts) { {'pp_uuid' => 'ED803750-E3C7-44F5-BB08-41A04433FE2E', '1.3.6.1.4.1.34380.1.2.1' => 'ssl-termination'} }
+```
+
+You can also create a set of default certificate extensions provided to all specs in your spec_helper:
+
+```ruby
+RSpec.configure do |c|
+  c.default_trusted_facts = {
+    'pp_uuid'                 => 'ED803750-E3C7-44F5-BB08-41A04433FE2E',
+    '1.3.6.1.4.1.34380.1.2.1' => 'ssl-termination'
+  }
+end
+```
+
 #### Testing Exported Resources
 
 You can test if a resource was exported from the catalogue by using the

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -23,6 +23,7 @@ RSpec.configure do |c|
   c.add_setting :config, :default => nil
   c.add_setting :confdir, :default => '/etc/puppet'
   c.add_setting :default_facts, :default => {}
+  c.add_setting :default_trusted_facts, :default => {}
   c.add_setting :hiera_config, :default => '/dev/null'
   c.add_setting :parser, :default => 'current'
   c.add_setting :trusted_node_data, :default => false

--- a/spec/classes/trusted_facts_spec.rb
+++ b/spec/classes/trusted_facts_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'trusted_facts', :if => Puppet.version.to_f >= 4.3 do
+  context 'without node set' do
+    it { should contain_class('trusted_facts') }
+    it { should compile.with_all_deps }
+    it { should contain_notify("certname-my_node.my_node") }
+    it { should contain_notify("authenticated-remote") }
+    it { should contain_notify("hostname-my_node") }
+    it { should contain_notify("domain-my_node") }
+    it { should contain_notify("no-extensions") }
+  end
+
+  context 'FQDN as certname' do
+    let(:node) { 'trusted.example.com' }
+    it { should contain_class('trusted_facts') }
+    it { should compile.with_all_deps }
+    it { should contain_notify("certname-#{node}") }
+    it { should contain_notify("authenticated-remote") }
+    it { should contain_notify("hostname-trusted") }
+    it { should contain_notify("domain-example.com") }
+    it { should contain_notify("no-extensions") }
+  end
+
+  context 'shortname as certname' do
+    let(:node) { 'trusted' }
+
+    it { should contain_class('trusted_facts') }
+    it { should compile.with_all_deps }
+    it { should contain_notify("certname-#{node}") }
+    it { should contain_notify("authenticated-remote") }
+    it { should contain_notify("hostname-trusted") }
+    it { should contain_notify("domain-") }
+    it { should contain_notify("no-extensions") }
+  end
+
+  context 'with extensions' do
+    extensions = {
+      'pp_uuid'                 => 'ED803750-E3C7-44F5-BB08-41A04433FE2E',
+      '1.3.6.1.4.1.34380.1.2.1' => 'ssl-termination'
+    }
+    let(:trusted_facts) { extensions }
+    let(:node) { 'trusted.example.com' }
+
+    it { should contain_class('trusted_facts') }
+    it { should compile.with_all_deps }
+    it { should contain_notify("certname-#{node}") }
+    it { should contain_notify("authenticated-remote") }
+    it { should contain_notify("hostname-trusted") }
+    it { should contain_notify("domain-example.com") }
+    it { should_not contain_notify("no-extensions") }
+    extensions.each do |k,v|
+      it { should contain_notify("extension-#{k}-#{v}") }
+    end
+  end
+end

--- a/spec/fixtures/modules/trusted_facts/manifests/init.pp
+++ b/spec/fixtures/modules/trusted_facts/manifests/init.pp
@@ -1,0 +1,14 @@
+class trusted_facts {
+  notify { "certname-${trusted['certname']}": }
+  notify { "authenticated-${trusted['authenticated']}": }
+  notify { "domain-${trusted['domain']}": }
+  notify { "hostname-${trusted['hostname']}": }
+
+  if $trusted['extensions'] == {} {
+    notify { "no-extensions": }
+  } else {
+    $trusted['extensions'].each |$k, $v| {
+      notify { "extension-${k}-${v}": }
+    }
+  }
+}


### PR DESCRIPTION
Set the standard trusted fact keys based on the 'node' name

Add 'trusted_facts' option to allow setting custom
trusted fact extensions.