### PR TITLE
Do not freeze classes passed into functions

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -16,7 +16,7 @@ module RSpec::Puppet
       # This method is used by the `run` matcher to trigger the function execution, and provides a uniform interface across all puppet versions.
       def execute(*args)
         # puppet 4 arguments are immutable
-        args.map(&:freeze)
+        args.reject { |a| a.is_a?(Class) }.each(&:freeze)
         Puppet.override(@overrides, "rspec-test scope") do
           @func.call(@overrides[:global_scope], *args)
         end

--- a/spec/fixtures/modules/test/lib/puppet/functions/frozen_function.rb
+++ b/spec/fixtures/modules/test/lib/puppet/functions/frozen_function.rb
@@ -1,5 +1,5 @@
 Puppet::Functions.create_function(:frozen_function) do
   def frozen_function(value)
-    value.reverse!
+    value.frozen?
   end
 end

--- a/spec/functions/test_function_spec.rb
+++ b/spec/functions/test_function_spec.rb
@@ -6,5 +6,6 @@ describe 'test_function', :if => Puppet.version.to_f >= 4.0 do
 end
 
 describe 'frozen_function', :if => Puppet.version.to_f >= 4.0 do
-  it { is_expected.to run.with_params('foo').and_raise_error(RuntimeError, %r{can't modify frozen}) }
+  it { is_expected.to run.with_params('foo').and_return(true) }
+  it { is_expected.to run.with_params(String).and_return(false) }
 end


### PR DESCRIPTION
Freezing a class prevents it from being modified at all, which can
happen in unit tests with mocha or rspec-expections.

Calling a function with `String` as an argument will freeze the entire
class and prevent `allow_any_instance_of(String)...` type expectations
from adding their hooks to the class.

e.g. stdlib:
  https://github.com/puppetlabs/puppetlabs-stdlib/blob/00c881d/spec/functions/is_a_spec.rb#L18
  https://github.com/puppetlabs/puppetlabs-stdlib/blob/00c881d/spec/functions/pw_hash_spec.rb#L57