### PR TITLE
Deep freeze only strings, arrays and hashes

### DIFF
--- a/spec/fixtures/modules/test/lib/puppet/functions/frozen_array_function.rb
+++ b/spec/fixtures/modules/test/lib/puppet/functions/frozen_array_function.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:frozen_array_function) do
+  def frozen_array_function(value)
+    value.frozen? && value.all?(&:frozen?)
+  end
+end

--- a/spec/fixtures/modules/test/lib/puppet/functions/frozen_function.rb
+++ b/spec/fixtures/modules/test/lib/puppet/functions/frozen_function.rb
@@ -1,5 +1,5 @@
 Puppet::Functions.create_function(:frozen_function) do
   def frozen_function(value)
-    value.reverse!
+    value.frozen?
   end
 end

--- a/spec/fixtures/modules/test/lib/puppet/functions/frozen_hash_function.rb
+++ b/spec/fixtures/modules/test/lib/puppet/functions/frozen_hash_function.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:frozen_hash_function) do
+  def frozen_hash_function(value)
+    value.frozen? && value.all? { |k,v| k.frozen? && v.frozen? }
+  end
+end

--- a/spec/functions/test_function_spec.rb
+++ b/spec/functions/test_function_spec.rb
@@ -6,5 +6,9 @@ describe 'test_function', :if => Puppet.version.to_f >= 4.0 do
 end
 
 describe 'frozen_function', :if => Puppet.version.to_f >= 4.0 do
-  it { is_expected.to run.with_params('foo').and_raise_error(RuntimeError, %r{can't modify frozen}) }
+  it { is_expected.to run.with_params('foo').and_return(true) }
+  it { is_expected.to run.with_params(String).and_return(false) }
+  it { is_expected.to run.with_params(true).and_return(true) }
+  it { is_expected.to run.with_params(['foo']).and_return(true) }
+  it { is_expected.to run.with_params('foo' => 'bar').and_return(true) }
 end


### PR DESCRIPTION
Freezing a class prevents it from being modified at all, which can
happen in unit tests with mocha or rspec-expections.

Calling a function with `String` as an argument will freeze the entire
class and prevent `allow_any_instance_of(String)...` type expectations
from adding their hooks to the class.

e.g. stdlib:
  https://github.com/puppetlabs/puppetlabs-stdlib/blob/00c881d/spec/functions/is_a_spec.rb#L18
  https://github.com/puppetlabs/puppetlabs-stdlib/blob/00c881d/spec/functions/pw_hash_spec.rb#L57

This whitelists strings, arrays and hashes as safe classes to freeze
when testing functions, others are left thawed to prevent side effects.
Deep freezing is used on arrays/hashes to match Puppet's behaviour of
freezing facts.

---

Alternative to #446 with a whitelisted set of classes instead of blacklisting Class specifically. This is closer to Puppet's implementation at https://github.com/puppetlabs/puppet/blob/master/lib/puppet/parser/scope.rb#L775, per the discussion on #442.