### PR TITLE
Don't enable app_management on Puppet 5

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -195,7 +195,7 @@ module RSpec::Puppet
       Puppet[:vardir] = vardir
 
       # Enable app_management by default for Puppet versions that support it
-      if Puppet.version.to_f >= 4.3
+      if Puppet.version.to_f >= 4.3 && Puppet.version.to_i < 5
         Puppet[:app_management] = true
       end
 


### PR DESCRIPTION
Triggers a deprecation warning as the setting is no longer necessary,
causing warn() expectations in stdlib's deprecation() tests to fail.