### PR TITLE
Fix environment override on 4.x (#440)

### DIFF
--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -146,6 +146,9 @@ module RSpec::Puppet
 
       def catalog(node, exported)
         node.environment = current_environment
+        # Override $::environment to workaround PUP-5835, where Puppet otherwise
+        # stores a symbol for the parameter
+        node.parameters['environment'] = current_environment.name.to_s if node.parameters['environment'] != node.parameters['environment'].to_s
         super
       end
 

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -27,6 +27,11 @@ node 'facts.acme.com' {
   file { 'environment':
     path => $environment
   }
+  if $::environment == 'test_env' {
+    file { 'conditional_file':
+      path => 'ignored'
+    }
+  }
   file { 'clientversion':
     path => $clientversion
   }

--- a/spec/hosts/environment_spec.rb
+++ b/spec/hosts/environment_spec.rb
@@ -4,7 +4,8 @@ describe 'facts.acme.com' do
   context 'without an explicit environment setting' do
     it { should contain_file('environment').with_path('rp_env') }
   end
-  context 'when specifying an explicit environment' do
+  # Broken on ~> 3.8.5 since PUP-5522
+  context 'when specifying an explicit environment', :unless => (Puppet.version >= '3.8.5' && Puppet.version.to_i < 4) do
     let(:environment) { 'test_env' }
     it { should contain_file('environment').with_path('test_env') }
     it { should contain_file('conditional_file') }

--- a/spec/hosts/environment_spec.rb
+++ b/spec/hosts/environment_spec.rb
@@ -7,5 +7,6 @@ describe 'facts.acme.com' do
   context 'when specifying an explicit environment' do
     let(:environment) { 'test_env' }
     it { should contain_file('environment').with_path('test_env') }
+    it { should contain_file('conditional_file') }
   end
 end

--- a/spec/unit/matchers/compile_spec.rb
+++ b/spec/unit/matchers/compile_spec.rb
@@ -144,14 +144,14 @@ if Puppet.version.to_f >= 3.0
       end
 
       context "when expecting the failure" do
-        before(:each) { subject.and_raise_error("Evaluation Error: Error while evaluating a Function Call, failure at line 47:1 on node rspec::puppet::manifestmatchers::compile") }
+        before(:each) { subject.and_raise_error("Evaluation Error: Error while evaluating a Function Call, failure at line 52:1 on node rspec::puppet::manifestmatchers::compile") }
 
         if Puppet.version.to_f >= 4.0
           # the error message above is puppet4 specific
           it ("matches") { is_expected.to be_matches catalogue }
         end
         it { is_expected.to have_attributes(
-          :description => "fail to compile and raise the error \"Evaluation Error: Error while evaluating a Function Call, failure at line 47:1 on node rspec::puppet::manifestmatchers::compile\""
+          :description => "fail to compile and raise the error \"Evaluation Error: Error while evaluating a Function Call, failure at line 52:1 on node rspec::puppet::manifestmatchers::compile\""
         )}
 
         context "after matching" do


### PR DESCRIPTION
Replaces #453 to fix #440 on 4.0 to 4.3, unable to fix it neatly on 3.8.5 to .7 though.

---

**Override $::environment parameter on Puppet 4.0 - 4.3**

Prevents environment parameter being set to a symbol, which cannot
otherwise be compared correctly to strings in manifests. Fixed by
puppetlabs/puppet@0296d2d.

Fixes #440 

---

**Disable environment override test on Puppet ~> 3.8.5**

Broken since PUP-5522 (puppetlabs/puppet@8136aff), without a clear
solution.