### PR TITLE
Stop automatically downcasing function name being tested

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -80,7 +80,7 @@ module RSpec::Puppet
     end
 
     def find_function
-      function_name = self.class.top_level_description.downcase
+      function_name = self.class.top_level_description
 
       with_vardir do
         env = adapter.current_environment

--- a/spec/fixtures/modules/test/lib/puppet/parser/functions/camelCaseFunction.rb
+++ b/spec/fixtures/modules/test/lib/puppet/parser/functions/camelCaseFunction.rb
@@ -1,0 +1,7 @@
+module Puppet::Parser::Functions
+  newfunction(:camelCaseFunction, :type => :rvalue) do |args|
+    raise Puppet::ParseError, "Requires 1 argument" unless args.length == 1
+    raise Puppet::ParseError, "Argument must be a string" unless args.first.is_a?(String)
+    return "test"
+  end
+end

--- a/spec/functions/camelCaseFunction_spec.rb
+++ b/spec/functions/camelCaseFunction_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'camelCaseFunction' do
+  it { is_expected.not_to be_nil }
+  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /Requires 1 argument/) }
+  it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, /Argument must be a string/) }
+  it { is_expected.to run.with_params('test').and_return('test') }
+end

--- a/spec/functions/camelCaseFunction_spec.rb
+++ b/spec/functions/camelCaseFunction_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'camelCaseFunction' do
-  it { is_expected.not_to be_nil }
-  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /Requires 1 argument/) }
-  it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, /Argument must be a string/) }
-  it { is_expected.to run.with_params('test').and_return('test') }
+  it { should_not be_nil }
+  it { should run.with_params().and_raise_error(Puppet::ParseError, /Requires 1 argument/) }
+  it { should run.with_params(1).and_raise_error(Puppet::ParseError, /Argument must be a string/) }
+  it { should run.with_params('test').and_return('test') }
 end


### PR DESCRIPTION
I didn't think that Puppet would allow capitals in function names, but after looking through the language docs it seems that there's nothing preventing it.

This PR changes the behavior of the function example group so that it no longer downcases the top level description text (the function name in this case).

Fixes #388