### PR TITLE
Don't assume all resource titles will be strings

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -88,9 +88,9 @@ module RSpec::Puppet
         end
       elsif type == :define
         if opts.has_key?(:params)
-          "#{class_name} { '#{title}': #{param_str(opts[:params])} }"
+          "#{class_name} { #{title.inspect}: #{param_str(opts[:params])} }"
         else
-          "#{class_name} { '#{title}': }"
+          "#{class_name} { #{title.inspect}: }"
         end
       elsif type == :host
         nil

--- a/spec/defines/test_loop_define_spec.rb
+++ b/spec/defines/test_loop_define_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'test::loop_define' do
+  let(:title) { ['a', 'b'] }
+
+  context 'both sub resources in the catalogue' do
+    it { should contain_package('a') }
+    it { should contain_package('b') }
+  end
+end

--- a/spec/fixtures/modules/test/manifests/loop_define.pp
+++ b/spec/fixtures/modules/test/manifests/loop_define.pp
@@ -1,0 +1,3 @@
+define test::loop_define() {
+  package { $name: }
+}


### PR DESCRIPTION
Previously when rendering the test manifest to be compiled we would just simply quote whatever value is passed in as the title. Unfortunately, if someone was quite validly trying to pass an array as the title you'd get `type { '[title, title2]': }` instead of `type { ['title', 'title2']: }`.

This PR changes the behaviour so that titles are rendered using Object#inspect, so that strings will still be quoted, but arrays will not.

Fixes #308