### PR TITLE
Support testing a pre-compiled catalogue in the create_generic matcher

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -79,7 +79,7 @@ module RSpec::Puppet
 
       def matches?(catalogue)
         ret = true
-        @catalogue = catalogue.call
+        @catalogue = catalogue.is_a?(Puppet::Resource::Catalog) ? catalogue : catalogue.call
         resource = @catalogue.resource(@referenced_type, @title)
 
         if resource.nil?

--- a/spec/fixtures/modules/test/lib/puppet/parser/functions/ensure_packages.rb
+++ b/spec/fixtures/modules/test/lib/puppet/parser/functions/ensure_packages.rb
@@ -1,0 +1,4 @@
+Puppet::Parser::Functions.newfunction(:ensure_packages, :type => :statement) do |args|
+  Puppet::Parser::Functions.function(:create_resources)
+  function_create_resources(['Package', { args.first => {'ensure' => 'present'} }])
+end

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'ensure_packages' do
+  before { subject.call(['facter']) }
+
+  it 'should create the resource in the catalogue' do
+    expect(catalogue).to contain_package('facter').with_ensure('present')
+    expect(lambda { catalogue }).to contain_package('facter').with_ensure('present')
+  end
+end


### PR DESCRIPTION
So that when testing functions that change the catalogue you no longer have to do the lambda workaround (although that'll still work for backwards compatibility) in order to use the standard catalogue matchers.

Fixes #297