### PR TITLE
Allow checking nil parameters with Procs

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -55,7 +55,7 @@ module RSpec::Puppet
       #
       # @return [true, false] If the resource matched
       def check(expected, actual)
-        return false if actual.nil? && !expected.nil?
+        return false if !expected.is_a?(Proc) && actual.nil? && !expected.nil?
         case expected
         when Proc
           check_proc(expected, actual)

--- a/spec/classes/test_classes_used_spec.rb
+++ b/spec/classes/test_classes_used_spec.rb
@@ -12,4 +12,5 @@ describe 'test::classes_used' do
 
   it { should contain_class('test::parameterised_class').with_text('bar') }
   it { should contain_class('test::bare_class') }
+  it { should contain_class('test::parameterised_class').with_something(Proc.new { |v| v.nil? || v.empty? }) }
 end

--- a/spec/fixtures/modules/test/manifests/parameterised_class.pp
+++ b/spec/fixtures/modules/test/manifests/parameterised_class.pp
@@ -1,3 +1,3 @@
-class test::parameterised_class($text) {
+class test::parameterised_class($text, $something = undef) {
   notify { $text: }
 }


### PR DESCRIPTION
The parameter check method preempts the more expensive evaluations by checking if the actual value is nil and the expected value is not nil and returning false. This works most of the time except when the user passes a Proc as the expected value which itself is not nil but can evaluate to nil.

This PR prevents this preemptive check from running if the expected value is a Proc.

Closes #275