### PR TITLE
Don't munge param values into Arrays with the splat operator

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -30,7 +30,7 @@ module RSpec::Puppet
         # Puppet flattens an array with a single value into just the value and
         # this can cause confusion when testing as people expect when you put
         # an array in, you'll get an array out.
-        actual = [*actual] if expected.is_a?(Array)
+        actual = [actual] if expected.is_a?(Array) && !actual.is_a?(Array)
 
         retval = check(expected, actual)
 

--- a/spec/classes/test_basic_spec.rb
+++ b/spec/classes/test_basic_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'test::basic' do
+  it { should contain_fake('foo').with_three([{'foo' => 'bar'}]) }
+end

--- a/spec/fixtures/modules/test/manifests/basic.pp
+++ b/spec/fixtures/modules/test/manifests/basic.pp
@@ -1,0 +1,5 @@
+class test::basic() {
+  fake { 'foo':
+    three => [{'foo' => 'bar'}],
+  }
+}


### PR DESCRIPTION
Backstory: Puppet < 4.0 used to convert single value arrays into the bare value internally, which is why this bit of code exists (the principle of least suprise dictates that if you pass in `['foo']` you should get `['foo']` back instead of `'foo'`).

The splat (`*`) is a convenient way of accomplishing this as if the value is already an Array, it won't end up as an Array nested inside an Array (`[*['foo']]` becomes `['foo']`). Unfortunately, if the value is a Hash, it'll get converted to an Array first (`[*{'foo' => 'bar'}]` becomes `[['foo', 'bar']]`.

This PR removes the use of the splat and instead adds a conditional to ensure that the value is not already an Array (avoiding the Array inside an Array situation that the splat was originally to solve).

Splat is a fun word to use professionally, hence the overly verbose description of this issue.

Closes #253