### PR TITLE
Use versioncmp to check Puppet version for 4.10.x compatibility

### DIFF
--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -202,15 +202,15 @@ module RSpec::Puppet
 
     def self.get
       [
-        [4.0, Adapter4X],
-        [3.0, Adapter3X],
-        [2.7, Adapter27]
+        ['4.0', Adapter4X],
+        ['3.0', Adapter3X],
+        ['2.7', Adapter27]
       ].each do |(version, klass)|
-        if Puppet.version.to_f >= version
+        if Puppet::Util::Package.versioncmp(Puppet.version, version) >= 0
           return klass.new
         end
       end
-      raise "Puppet version #{Puppet.version.to_f} is not supported."
+      raise "Puppet version #{Puppet.version} is not supported."
     end
   end
 end

--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -151,7 +151,7 @@ module RSpec::Puppet
 
       node = build_node(node_name, node_options)
 
-      if Puppet.version.to_f >= 4.3
+      if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
         Puppet.push_context(
           {
             :trusted_information => Puppet::Context::TrustedInformation.new('remote', node_name, trusted_values)

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -147,7 +147,7 @@ module RSpec::Puppet
     end
 
     def trusted_facts_hash(node_name)
-      return {} unless Puppet.version.to_f >= 4.3
+      return {} unless Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
 
       extensions = {}
 
@@ -195,7 +195,7 @@ module RSpec::Puppet
       Puppet[:vardir] = vardir
 
       # Enable app_management by default for Puppet versions that support it
-      if Puppet.version.to_f >= 4.3 && Puppet.version.to_i < 5
+      if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 && Puppet.version.to_i < 5
         Puppet[:app_management] = true
       end
 
@@ -236,7 +236,7 @@ module RSpec::Puppet
 
       node_obj = Puppet::Node.new(nodename, { :parameters => facts_val, :facts => node_facts })
 
-      if Puppet.version.to_f >= 4.3
+      if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
         Puppet.push_context(
           {
             :trusted_information => Puppet::Context::TrustedInformation.new('remote', nodename, trusted_facts_val)

--- a/spec/applications/orch_app_spec.rb
+++ b/spec/applications/orch_app_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'orch_app', :if => Puppet.version.to_f >= 4.3 do
+describe 'orch_app', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
   let(:node) { 'my_node' }
   let(:title) { 'my_awesome_app' }
 

--- a/spec/classes/trusted_facts_spec.rb
+++ b/spec/classes/trusted_facts_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'trusted_facts', :if => Puppet.version.to_f >= 4.3 do
+describe 'trusted_facts', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
   context 'without node set' do
     it { should contain_class('trusted_facts') }
     it { should compile.with_all_deps }

--- a/spec/functions/facts_lookup_spec.rb
+++ b/spec/functions/facts_lookup_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec-puppet'
 
-describe 'structured_facts::lookup', :if => Puppet.version.to_f >= 4.3 do
+describe 'structured_facts::lookup', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
   context 'with one set of values' do
     let(:facts) {{ 'os' => {'family' => 'RedHat'} }}
 

--- a/spec/functions/split_spec.rb
+++ b/spec/functions/split_spec.rb
@@ -4,15 +4,15 @@ describe 'split' do
   it { should run.with_params('aoeu', 'o').and_return(['a', 'eu']) }
   it { should_not run.with_params('foo').and_raise_error(Puppet::DevError) }
 
-  if (Puppet.version.split('.').map { |s| s.to_i } <=> [3, 1]) >= 0
+  if Puppet::Util::Package.versioncmp(Puppet.version, '3.1.0') >= 0
     expected_error = ArgumentError
   else
     expected_error = Puppet::ParseError
   end
 
-  if Puppet.version.to_f >= 4.3
+  if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
     expected_error_message = /expects \d+ arguments/
-  elsif Puppet.version.to_f >= 4.0
+  elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0
     expected_error_message = /mis-matched arguments/
   else
     expected_error_message = /number of arguments/

--- a/spec/functions/test_hiera_function_spec.rb
+++ b/spec/functions/test_hiera_function_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'test::hiera_function', :if => Puppet.version.to_f >= 4.3 do
+describe 'test::hiera_function', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
   context 'with :hiera_config set' do
     let(:hiera_config) { 'spec/fixtures/hiera.yaml' }
     it { should run.and_return('foo') }

--- a/spec/functions/trusted_facts_lookup_spec.rb
+++ b/spec/functions/trusted_facts_lookup_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'trusted_facts::lookup', :if => Puppet.version.to_f >= 4.3 do
+describe 'trusted_facts::lookup', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
   let(:node) { 'trusted.example.com' }
 
   context 'without trusted fact extensions' do

--- a/spec/type_aliases/onlyarray_spec.rb
+++ b/spec/type_aliases/onlyarray_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Aliases::OnlyArray', :if => Puppet.version.to_f >= 4.4 do
+describe 'Aliases::OnlyArray', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0 do
   it { is_expected.not_to allow_value(nil, 'string') }
   it { is_expected.to allow_value(['a', 'b']) }
 end

--- a/spec/type_aliases/onlyhash_spec.rb
+++ b/spec/type_aliases/onlyhash_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Aliases::OnlyHash', :if => Puppet.version.to_f >= 4.4 do
+describe 'Aliases::OnlyHash', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0 do
   it { is_expected.not_to allow_value(nil, 'string') }
   it { is_expected.to allow_value({'a' => 'b'}) }
   it { is_expected.to allow_value({'a' => {'b' => 'c'}}) }

--- a/spec/type_aliases/shape_spec.rb
+++ b/spec/type_aliases/shape_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Aliases::Shape', :if => Puppet.version.to_f >= 4.4 do
+describe 'Aliases::Shape', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0 do
   it { is_expected.to allow_value('square') }
   it { is_expected.to allow_value('circle') }
   it { is_expected.not_to allow_value('triangle') }


### PR DESCRIPTION
`Puppet.version.to_f` on Puppet 4.10.0 will evaluate to `4.1`, causing
test and behavioural changes when conditionals check that the version is
equal or greater than versions such as `4.3`.

Version comparisons that are vulnerable to this have been changed to use
Puppet's versioncmp implementation, while most others only check for
for major version boundaries which is safe.

---

This (or equivalent change) ought to be _released_ too before 4.10.x to prevent problems in module tests on 4.10's release.