### PR TITLE
Update travis config to test current supported Puppet versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ matrix:
       env: PUPPET_GEM_VERSION='~> 4.8.0' COVERAGE=yes
 
   allowed_failures:
-    - env: PUPPET_GEM_VERSION='git:https://github.com/puppetlabs/puppet.git#master'
+    # Don't fail for puppet.git#master because it may be to blame for any failures
+    - env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache: bundler
 bundler_args: --without development
 
 rvm:
+  - 2.3.0
   - 2.1
   - 1.9.3
-  - 2.0.0
 
 sudo: false
 
@@ -36,7 +36,7 @@ matrix:
     # run Coveralls exactly once
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION='~> 4.8.0' COVERAGE=yes
-    - rvm: 2.0.0
+    - rvm: 2.3.0
       env: PUPPET_GEM_VERSION='~> 4.8.0' COVERAGE=yes
 
   allowed_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,17 @@ rvm:
 sudo: false
 
 env:
-  - PUPPET_GEM_VERSION='~> 4.7.0' COVERAGE=yes
-  - PUPPET_GEM_VERSION='~> 2.7.0'
-  - PUPPET_GEM_VERSION='~> 3.7.0'
-  - PUPPET_GEM_VERSION='~> 3.8.0'
-  - PUPPET_GEM_VERSION='~> 4.0.0'
-  - PUPPET_GEM_VERSION='~> 4.1.0'
-  - PUPPET_GEM_VERSION='~> 4.2.0'
-  - PUPPET_GEM_VERSION='~> 4.3.0'
+  - PUPPET_GEM_VERSION='~> 4.8.0' COVERAGE=yes
   - PUPPET_GEM_VERSION='~> 4.7.0'
+  - PUPPET_GEM_VERSION='~> 4.5.0'
+  - PUPPET_GEM_VERSION='~> 4.4.0'
+  - PUPPET_GEM_VERSION='~> 4.3.0'
+  - PUPPET_GEM_VERSION='~> 4.2.0'
+  # Latest gem release
+  - PUPPET_GEM_VERSION='~> 4.0'
+  # Latest code from puppetlabs/puppet.git
   - PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master'
   - PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#stable'
-  - PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#3.x'
 
 matrix:
   include:
@@ -32,25 +31,13 @@ matrix:
       env: PUPPET_GEM_VERSION='~> 2.7.0' RSPEC_GEM_VERSION='~> 2.14.0'
 
   exclude:
-    # newer puppet versions don't run on 1.8.7
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION='~> 4.0.0'
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION='~> 4.1.0'
     - rvm: 2.1
       env: PUPPET_GEM_VERSION='~> 4.1.0'
-    # puppet 2.7 doesn't run on newer rubies
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION='~> 2.7.0'
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION='~> 2.7.0'
-    - rvm: 2.1
-      env: PUPPET_GEM_VERSION='~> 2.7.0'
     # run Coveralls exactly once
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION='~> 4.7.0' COVERAGE=yes
+      env: PUPPET_GEM_VERSION='~> 4.8.0' COVERAGE=yes
     - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION='~> 4.7.0' COVERAGE=yes
+      env: PUPPET_GEM_VERSION='~> 4.8.0' COVERAGE=yes
 
   allowed_failures:
     - env: PUPPET_GEM_VERSION='git:https://github.com/puppetlabs/puppet.git#master'


### PR DESCRIPTION
Update travis config to test current supported Puppet versions.
Also includes a commit to fix a typo in one of the test exclusions.
Also adds a note to README.md to point users to the v.2.5.0 tag if they want to retain testing against older Puppet versions.