### PR TITLE
Stop testing against Puppet 2.x (it's time)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ sudo: false
 
 env:
   - PUPPET_GEM_VERSION='~> 4.7.0' COVERAGE=yes
-  - PUPPET_GEM_VERSION='~> 2.7.0'
   - PUPPET_GEM_VERSION='~> 3.7.0'
   - PUPPET_GEM_VERSION='~> 3.8.0'
   - PUPPET_GEM_VERSION='~> 4.0.0'
@@ -28,8 +27,6 @@ matrix:
     # these versions are explicitly needed for ruby 1.8.7 support
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION='~> 3.8.0' RSPEC_GEM_VERSION='= 3.1.0'
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION='~> 2.7.0' RSPEC_GEM_VERSION='~> 2.14.0'
 
   exclude:
     # newer puppet versions don't run on 1.8.7
@@ -39,13 +36,6 @@ matrix:
       env: PUPPET_GEM_VERSION='~> 4.1.0'
     - rvm: 2.1
       env: PUPPET_GEM_VERSION='~> 4.1.0'
-    # puppet 2.7 doesn't run on newer rubies
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION='~> 2.7.0'
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION='~> 2.7.0'
-    - rvm: 2.1
-      env: PUPPET_GEM_VERSION='~> 2.7.0'
     # run Coveralls exactly once
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION='~> 4.7.0' COVERAGE=yes
@@ -57,4 +47,4 @@ matrix:
 
 notifications:
   email:
-    - tim@github.com
+    - tim@bombasticmonkey.com


### PR DESCRIPTION
Puppet 3.x has been EOLed, and Puppet 5 is not far away. Let's stop testing against Puppet 2.x now.