### PR TITLE
DO NOT MERGE (SDK-116) Enable appveyor testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,11 @@ end
 
 gemspec
 
+# ffi (specifically the x64-mingw32 variant) requires ruby >= 2.0 after version 1.9.14 
+if RUBY_VERSION =~ /^1\.?9/
+  gem 'ffi', '<= 1.9.14'
+end
+
 gem 'rspec', *location_for(ENV['RSPEC_GEM_VERSION'] || '~> 3.0')
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'] || '~> 4.0')
 gem 'pry', :group => :development

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'rspec', *location_for(ENV['RSPEC_GEM_VERSION'] || '~> 3.0')
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'] || '~> 4.0')
 gem 'pry', :group => :development
 
-if RUBY_VERSION =~ /^1\./
+if RUBY_VERSION =~ /^1\.?/
   gem 'rake', '10.5.0' # still supports 1.8
 else
   gem 'rake'
@@ -25,15 +25,15 @@ end
 # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure 2.0.1
 # if using ruby 1.9; older ruby versions do not support puppets that require
 # these gems.
-if RUBY_VERSION =~ /^1\.9/
+if RUBY_VERSION =~ /^1\.?9/
   gem 'json_pure', '<=2.0.1'
   # rubocop 0.42.0 requires ruby >=2; 1.8 is not supported
-  gem 'rubocop', '0.41.2'       if RUBY_VERSION =~ /^1\.9/
-elsif RUBY_VERSION =~ /^1\.8/
+  gem 'rubocop', '0.41.2'       if RUBY_VERSION =~ /^1\.?9/
+elsif RUBY_VERSION =~ /^1\.?8/
   gem 'json_pure', '< 2.0.0'
 else
   gem 'rubocop'
-  gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop-rspec', '~> 1.6' if (RUBY_VERSION >= '2.3.0' || RUBY_VERSION >= '23')
 end
 
 if ENV['COVERAGE'] == 'yes'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,76 @@
+build: off
+
+branches:
+  only:
+    - master
+
+# ruby versions under test
+environment:
+  matrix:
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.8.0'
+    - RUBY_VERSION: 21
+      PUPPET_GEM_VERSION: '~> 4.8.0'
+    - RUBY_VERSION: 193
+      PUPPET_GEM_VERSION: '~> 4.8.0' 
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.7.0'
+    - RUBY_VERSION: 21
+      PUPPET_GEM_VERSION: '~> 4.7.0'
+    - RUBY_VERSION: 193
+      PUPPET_GEM_VERSION: '~> 4.7.0'
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.5.0'
+    - RUBY_VERSION: 21
+      PUPPET_GEM_VERSION: '~> 4.5.0'
+    - RUBY_VERSION: 193
+      PUPPET_GEM_VERSION: '~> 4.5.0'
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.4.0'
+    - RUBY_VERSION: 21
+      PUPPET_GEM_VERSION: '~> 4.4.0'
+    - RUBY_VERSION: 193
+      PUPPET_GEM_VERSION: '~> 4.4.0'
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.3.0'
+    - RUBY_VERSION: 21
+      PUPPET_GEM_VERSION: '~> 4.3.0'
+    - RUBY_VERSION: 193
+      PUPPET_GEM_VERSION: '~> 4.3.0'
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.2.0'
+    - RUBY_VERSION: 21
+      PUPPET_GEM_VERSION: '~> 4.2.0'
+    - RUBY_VERSION: 193
+      PUPPET_GEM_VERSION: '~> 4.2.0'
+    # Latest gem release
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: '~> 4.0'
+    # Latest code from puppetlabs/puppet.git
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: 'https://github.com/puppetlabs/puppet.git#master'
+    - RUBY_VERSION: 23-x64
+      PUPPET_GEM_VERSION: 'https://github.com/puppetlabs/puppet.git#stable'
+
+matrix:
+  allow_failures:
+    # Don't fail for puppet.git#master because it may be to blame for any failures
+    - PUPPET_GEM_VERSION: 'https://github.com/puppetlabs/puppet.git#master'
+
+install:
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - SET LOG_SPEC_ORDER=true
+  - ruby -v
+  - gem -v
+  - bundle -v
+  - bundle install --jobs 4 --retry 2 --without development
+
+before_test:
+  - type Gemfile.lock
+
+test_script:
+  - bundle exec rake test
+
+notifications:
+  email:
+    - tim@bombasticmonkey.com


### PR DESCRIPTION
Add appveyor config

The test combinations are much less than for .travis.yml due to:

1. We do not want to repeat all testing. Given that travis is green, we only want assurance that nothing Windows-specific is a problem.
2. appveyor is not as flexible as travis. It is not possible to matrix multiple environment variables into test permutations, or to define specific include/excludes from your matrix. You can only define each and every combination of environment variables you want tested.