### PR TITLE
Fixes expected error for missing dependency under Puppet 5

### DIFF
--- a/spec/unit/matchers/compile_spec.rb
+++ b/spec/unit/matchers/compile_spec.rb
@@ -62,7 +62,7 @@ if Puppet.version.to_f >= 3.0
         before(:each) { subject.matches? catalogue }
 
         it { is_expected.to have_attributes(
-          :failure_message => a_string_starting_with("error during compilation: Could not retrieve dependency 'File[/tmp/missing]'")
+          :failure_message => a_string_matching(%r{\Aerror during compilation: Could not (retrieve dependency|find resource) 'File\[/tmp/missing\]'})
         )}
       end
     end


### PR DESCRIPTION
Since PUP-5659, the message for a missing require dependency has changed
as it's now validated during catalog compilation:

    error during compilation: Could not find resource 'File[/tmp/missing]' in parameter 'require' at line 52 on node rspec::puppet::manifestmatchers::compile