### PR TITLE
Explicitly use the NullReporter for coverage tests

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -1,3 +1,15 @@
+unless defined?(RSpec::Core::NullReporter)
+  module RSpec::Core
+    class NullReporter
+    private
+
+      def method_missing(_method, *_args, &_block)
+        #noop
+      end
+    end
+  end
+end
+
 module RSpec::Puppet
   class Coverage
 
@@ -91,7 +103,7 @@ module RSpec::Puppet
         coverage_results = coverage_test.example("Must be at least #{coverage_desired}% of code coverage") {
           expect( coverage_actual.to_f ).to be >= coverage_desired.to_f
         }
-        coverage_test.run
+        coverage_test.run(RSpec::Core::NullReporter.new)
         passed = coverage_results.execution_result.status == :passed
 
         RSpec.configuration.reporter.example_failed coverage_results unless passed


### PR DESCRIPTION
This'll allow the minimum coverage check to work on rspec <= 3.2.

Fixes #397 