### PR TITLE
Add hiera_data to the cache key, for hiera-puppet-helper

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -26,8 +26,9 @@ module RSpec::Puppet
         node_name = nodename(type)
 
         hiera_config_value = self.respond_to?(:hiera_config) ? hiera_config : nil
+        hiera_data_value = self.respond_to?(:hiera_data) ? hiera_data : nil
 
-        catalogue = build_catalog(node_name, facts_hash(node_name), trusted_facts_hash(node_name), hiera_config_value, code, exported)
+        catalogue = build_catalog(node_name, facts_hash(node_name), trusted_facts_hash(node_name), hiera_config_value, code, exported, hiera_data_value)
 
         test_module = class_name.split('::').first
         RSpec::Puppet::Coverage.add_filter(type.to_s, self.class.description)
@@ -217,7 +218,7 @@ module RSpec::Puppet
       end
     end
 
-    def build_catalog_without_cache(nodename, facts_val, trusted_facts_val, hiera_config_val, code, exported)
+    def build_catalog_without_cache(nodename, facts_val, trusted_facts_val, hiera_config_val, code, exported, hiera_data_value)
 
       # If we're going to rebuild the catalog, we should clear the cached instance
       # of Hiera that Puppet is using.  This opens the possibility of the catalog


### PR DESCRIPTION
As mentioned in #215, we make hiera_config a part of the catalogue cache key, but not hiera_data (which is used by the popular rspec-hiera-puppet/hiera-puppet-helper gem) which can cause problems as users might get a cached catalogue even though they've supplied different hiera data.

This PR adds hiera_data (if provided with `let`) to the cache key to prevent this from happening.

Closes #215