### PR TITLE
Automatically filter out defined type being tested from the coverage report

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -31,7 +31,11 @@ module RSpec::Puppet
         catalogue = build_catalog(node_name, facts_hash(node_name), trusted_facts_hash(node_name), hiera_config_value, code, exported, hiera_data_value)
 
         test_module = type == :host ? nil : class_name.split('::').first
-        RSpec::Puppet::Coverage.add_filter(type.to_s, self.class.description)
+        if type == :define
+          RSpec::Puppet::Coverage.add_filter(class_name, title)
+        else
+          RSpec::Puppet::Coverage.add_filter(type.to_s, class_name)
+        end
         RSpec::Puppet::Coverage.add_from_catalog(catalogue, test_module)
 
         catalogue

--- a/spec/classes/test_api_spec.rb
+++ b/spec/classes/test_api_spec.rb
@@ -10,6 +10,10 @@ describe 'test::bare_class' do
       expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
 
+    it 'should be included in the coverage filter' do
+      expect(RSpec::Puppet::Coverage.filters).to include('Class[Test::Bare_class]')
+    end
+
     describe 'derivative group' do
       subject { catalogue.resource('Notify', 'foo') }
 

--- a/spec/defines/test_api_spec.rb
+++ b/spec/defines/test_api_spec.rb
@@ -12,5 +12,9 @@ describe 'sysctl' do
     it 'subject should return a catalogue' do
       expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
+
+    it 'should be included in the coverage filter' do
+      expect(RSpec::Puppet::Coverage.filters).to include('Sysctl[vm.swappiness]')
+    end
   end
 end


### PR DESCRIPTION
Previously, this code assumed everything being tested had the same puppet resource type as the example group name, so you'd end up with things like `Node[foo]`, `Class[bar]` being filtered out, but defined types would get a filter like `Define[my::define]` which of course didn't match.

This PR fixes this behaviour so that defined types get a proper filter added to the coverage report.

Closes #159