### PR TITLE
Generate coverage reports for host specs

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -41,7 +41,7 @@ module RSpec::Puppet
 
     # add all resources from catalog declared in module test_module
     def add_from_catalog(catalog, test_module)
-      coverable_resources = catalog.to_a.select { |resource| !filter_resource?(resource, test_module) }
+      coverable_resources = catalog.to_a.reject { |resource| !test_module.nil? && filter_resource?(resource, test_module) }
       coverable_resources.each do |resource|
         add(resource)
       end

--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -17,7 +17,7 @@ module RSpec::Puppet
 
     def initialize
       @collection = {}
-      @filters = ['Stage[main]', 'Class[Settings]', 'Class[main]']
+      @filters = ['Stage[main]', 'Class[Settings]', 'Class[main]', 'Node[default]']
     end
 
     def add(resource)

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -29,7 +29,7 @@ module RSpec::Puppet
 
         catalogue = build_catalog(node_name, facts_hash(node_name), trusted_facts_hash(node_name), hiera_config_value, code, exported)
 
-        test_module = class_name.split('::').first
+        test_module = type == :host ? nil : class_name.split('::').first
         RSpec::Puppet::Coverage.add_filter(type.to_s, self.class.description)
         RSpec::Puppet::Coverage.add_from_catalog(catalogue, test_module)
 

--- a/spec/hosts/test_api_spec.rb
+++ b/spec/hosts/test_api_spec.rb
@@ -9,5 +9,10 @@ describe 'foo.example.com' do
     it 'subject should return a catalogue' do
       expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
+
+    it 'should have resources in its coverage report' do
+      expect(RSpec::Puppet::Coverage.instance.results[:total]).to be > 0
+      expect(RSpec::Puppet::Coverage.instance.results[:resources]).to include('Notify[test]')
+    end
   end
 end

--- a/spec/unit/coverage_spec.rb
+++ b/spec/unit/coverage_spec.rb
@@ -19,7 +19,7 @@ describe RSpec::Puppet::Coverage do
 
   describe "filtering" do
     it "filters boilerplate catalog resources by default" do
-      expect(subject.filters).to eq %w[Stage[main] Class[Settings] Class[main]]
+      expect(subject.filters).to eq %w[Stage[main] Class[Settings] Class[main] Node[default]]
     end
 
     it "can add additional filters" do


### PR DESCRIPTION
This PR changes the behaviour of `RSpec::Puppet::Coverage#add_from_catalog` so that we can now pass `nil` as the `test_module` param to prevent it from filtering out any of the resources, which we now do for `:host` specs. Additionally, `Node[default]` has been added to the default coverage filter as one of those internal resources Puppet creates that you don't really care about when calculating code coverage.

Fixes #466