### PR TITLE
Don't check the value of the namevar param unless explicitly required

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -87,6 +87,11 @@ module RSpec::Puppet
         else
           RSpec::Puppet::Coverage.cover!(resource)
           rsrc_hsh = resource.to_hash
+
+          unless @expected_params.any? { |param| param.first == 'name' }
+            rsrc_hsh.delete(:name) if rsrc_hsh.has_key?(:name)
+          end
+
           if @expected_params_count
             unless rsrc_hsh.size == @expected_params_count
               ret = false

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -88,7 +88,12 @@ module RSpec::Puppet
           RSpec::Puppet::Coverage.cover!(resource)
           rsrc_hsh = resource.to_hash
 
-          namevar = resource.resource_type.key_attributes.first.to_s
+          if resource.resource_type.is_a?(Puppet::Resource::Type)
+            namevar = 'name'
+          else
+            namevar = resource.resource_type.key_attributes.first.to_s
+          end
+
           unless @expected_params.any? { |param| param.first.to_s == namevar }
             rsrc_hsh.delete(namevar.to_sym) if rsrc_hsh.has_key?(namevar.to_sym)
           end

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -88,8 +88,9 @@ module RSpec::Puppet
           RSpec::Puppet::Coverage.cover!(resource)
           rsrc_hsh = resource.to_hash
 
-          unless @expected_params.any? { |param| param.first == 'name' }
-            rsrc_hsh.delete(:name) if rsrc_hsh.has_key?(:name)
+          namevar = resource.resource_type.key_attributes.first.to_s
+          unless @expected_params.any? { |param| param.first.to_s == namevar }
+            rsrc_hsh.delete(namevar.to_sym) if rsrc_hsh.has_key?(namevar.to_sym)
           end
 
           if @expected_params_count

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -88,10 +88,10 @@ module RSpec::Puppet
           RSpec::Puppet::Coverage.cover!(resource)
           rsrc_hsh = resource.to_hash
 
-          if resource.resource_type.is_a?(Puppet::Resource::Type)
-            namevar = 'name'
-          else
+          if resource.builtin_type?
             namevar = resource.resource_type.key_attributes.first.to_s
+          else
+            namevar = 'name'
           end
 
           unless @expected_params.any? { |param| param.first.to_s == namevar }

--- a/spec/classes/test_user_spec.rb
+++ b/spec/classes/test_user_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'test::user' do
+  it { should contain_user('luke').only_with({
+    'ensure' => 'present',
+    'uid'    => '501',
+  }) }
+end

--- a/spec/fixtures/modules/test/manifests/user.pp
+++ b/spec/fixtures/modules/test/manifests/user.pp
@@ -1,0 +1,6 @@
+class test::user {
+  user { 'luke':
+    ensure => present,
+    uid    => '501',
+  }
+}


### PR DESCRIPTION
As raised in #133, when testing a resource parameters with `only_with`, it can fail if the user hasn't added the namevar parameter to the hash. This is most obvious when the namevar is the `name` parameter (like for the User type), as it's unlikely that it would be passed in the param hash. This is redundant as the namevar is already tested by specifying it as the parameter to `contain_<resource>`.

This PR changes the behaviour so that the namevar is removed from the resource parameters unless it is explicitly tested for.

Closes #133 