### PR TITLE
Provide the actual value for expected nil/undefined params

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -320,7 +320,7 @@ module RSpec::Puppet
 
           if value.nil? then
             unless resource[param].nil?
-              @errors << "#{param} undefined"
+              @errors << "#{param} undefined but it is set to #{resource[param].inspect}"
             end
           else
             m = ParameterMatcher.new(param, value, type)


### PR DESCRIPTION
If the user has a spec like `it { is_expected.to contain_user('luke').without_uid }`, change the error message if the spec fails so that it'll print out the value of the `uid` parameter, rather than simply stating that it was expected that uid was undefined.

Closes #216