### PR TITLE
Write a full spec_helper on init

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -115,7 +115,7 @@ module RSpec::Puppet
     end
 
     def self.safe_create_spec_helper
-      content = "require 'rspec-puppet/spec_helper'\n"
+      content = File.read(File.expand_path(File.join(__FILE__, '..', 'spec_helper.rb')))
       safe_create_file('spec/spec_helper.rb', content)
     end
 

--- a/lib/rspec-puppet/spec_helper.rb
+++ b/lib/rspec-puppet/spec_helper.rb
@@ -5,6 +5,6 @@ fixture_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures')
 RSpec.configure do |c|
   c.module_path     = File.join(fixture_path, 'modules')
   c.manifest_dir    = File.join(fixture_path, 'manifests')
-  c.manifest        = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests', 'site.pp')
+  c.manifest        = File.join(fixture_path, 'manifests', 'site.pp')
   c.environmentpath = File.join(Dir.pwd, 'spec')
 end

--- a/lib/rspec-puppet/spec_helper.rb
+++ b/lib/rspec-puppet/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rspec-puppet'
 
-fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+fixture_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures')
 
 RSpec.configure do |c|
   c.module_path     = File.join(fixture_path, 'modules')


### PR DESCRIPTION
The change in #300 (merged into master in #305) had the unfortunate side effect of breaking the `fixture_path` calculation which uses `__FILE__` for `spec_helper.rb` as the base for `File.expand_path`. Basically, it would end up configuring rspec-puppet to look for the manifests being tested in the installed gem instead of the user's project directory.

We could work around this by doing clever things like have the spec_helper check the `caller` stack to see if it has been required by another spec_helper and changing the `File.expand_path` base, but in my opinion that feels pretty fragile and I'd prefer to just go back to writing out the file for the user on init.

Fixes #395

/cc @DavidS as this basically undoes his change :)