### PR TITLE
Prevent infinite recursion when resolving complex relationships

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -1,4 +1,6 @@
+require 'set'
 require 'rspec-puppet/matchers/parameter_matcher'
+
 module RSpec::Puppet
   module ManifestMatchers
     class CreateGeneric
@@ -258,13 +260,21 @@ module RSpec::Puppet
         resource_ref(resource_from_ref(ref))
       end
 
-      def relationship_refs(resource, type)
+      def relationship_refs(resource, type, visited = Set.new)
         resource = canonicalize_resource(resource)
         results = []
         return results unless resource
+
+        # guard to prevent infinite recursion
+        if visited.include?(resource.object_id)
+          return [canonicalize_resource_ref(resource)]
+        else
+          visited << resource.object_id
+        end
+
         Array[resource[type]].flatten.compact.each do |r|
           results << canonicalize_resource_ref(r)
-          results << relationship_refs(r, type)
+          results << relationship_refs(r, type, visited)
         end
 
         # Add autorequires if any
@@ -272,7 +282,7 @@ module RSpec::Puppet
           resource.resource_type.eachautorequire do |t, b|
             Array(resource.to_ral.instance_eval(&b)).each do |dep|
               res = "#{t.to_s.capitalize}[#{dep}]"
-              if r = relationship_refs(res, type)
+              if r = relationship_refs(res, type, visited)
                 results << res
                 results << r
               end

--- a/spec/classes/relationships_complex_spec.rb
+++ b/spec/classes/relationships_complex_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'relationships::complex' do
+  it { should contain_notify('foo').that_comes_before(['Notify[baz]', 'Notify[bar]']) }
+end

--- a/spec/fixtures/modules/relationships/manifests/complex.pp
+++ b/spec/fixtures/modules/relationships/manifests/complex.pp
@@ -1,0 +1,14 @@
+class relationships::complex {
+  notify { 'foo':
+    before => Notify['bar'],
+  }
+
+  notify { 'bar':
+    before => Notify['baz'],
+  }
+
+  notify { 'baz':
+  }
+
+  Notify['baz'] -> Notify['foo']
+}

--- a/spec/fixtures/modules/relationships/manifests/complex.pp
+++ b/spec/fixtures/modules/relationships/manifests/complex.pp
@@ -10,5 +10,5 @@ class relationships::complex {
   notify { 'baz':
   }
 
-  Notify['baz'] -> Notify['foo']
+  Notify['baz'] <- Notify['foo']
 }


### PR DESCRIPTION
As raised in #418, when checking the relationships between resources where the relationships are a bit more complex (forward and backward edges between >2 resources), it is possible for `RSpec::Puppet::ManifestMatchers::CreateGeneric#relationship_refs` to get stuck in an infinite recursion loop.

This PR fixes that behaviour by adding a simple guard to the recursion to prevent `relationship_refs` from being called on the same resource multiple times.

Closes #418