### PR TITLE
Handle the cases when a resource's name is different to its title

### DIFF
--- a/lib/rspec-puppet/matchers/compile.rb
+++ b/lib/rspec-puppet/matchers/compile.rb
@@ -108,6 +108,10 @@ module RSpec::Puppet
               if vertex[:alias]
                 res_hash["#{vertex.type.to_s}[#{vertex[:alias]}]"] = 1
               end
+
+              if vertex.uniqueness_key != [vertex.title]
+                res_hash["#{vertex.type.to_s}[#{vertex.uniqueness_key.first}]"] = 1
+              end
             end
           end
           res_hash

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -262,6 +262,14 @@ module RSpec::Puppet
         resource = canonicalize_resource(resource)
         results = []
         return results unless resource
+
+        if resource.builtin_type?
+          name_var = resource.key_attributes.first
+          if resource.title != resource[name_var]
+            results << "#{resource.type}[#{resource[name_var]}]"
+          end
+        end
+
         Array[resource[type]].flatten.compact.each do |r|
           results << canonicalize_resource_ref(r)
           results << relationship_refs(r, type)

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -260,19 +260,18 @@ module RSpec::Puppet
 
       def relationship_refs(resource, type)
         resource = canonicalize_resource(resource)
-        results = []
+        results = Set.new
         return results unless resource
-
-        if resource.builtin_type?
-          name_var = resource.key_attributes.first
-          if resource.title != resource[name_var]
-            results << "#{resource.type}[#{resource[name_var]}]"
-          end
-        end
 
         Array[resource[type]].flatten.compact.each do |r|
           results << canonicalize_resource_ref(r)
           results << relationship_refs(r, type)
+
+          res = canonicalize_resource(r)
+          if res.builtin_type?
+            results << res.to_ref
+            results << "#{res.type.to_s.capitalize}[#{res.uniqueness_key}]"
+          end
         end
 
         # Add autorequires if any

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -298,8 +298,8 @@ module RSpec::Puppet
 
         self_or_upstream(first).each do |u|
           self_or_upstream(second).each do |v|
-            before_refs = relationship_refs(u, :before)
-            require_refs = relationship_refs(v, :require)
+            before_refs = relationship_refs(u, :before) + relationship_refs(u, :notify)
+            require_refs = relationship_refs(v, :require) + relationship_refs(u, :subscribe)
 
             if before_refs.include?(v.to_ref) || require_refs.include?(u.to_ref) || (before_refs & require_refs).any?
               return true

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -250,7 +250,13 @@ module RSpec::Puppet
         )
       end
 
-      adapter.catalog(node_obj, exported)
+      cat = adapter.catalog(node_obj, exported)
+      cat.resources.each do |resource|
+        if resource.uniqueness_key != [resource.title]
+          cat.alias(resource, resource.uniqueness_key.first)
+        end
+      end
+      cat
     end
 
     def stub_facts!(facts)

--- a/spec/classes/relationship__titles_spec.rb
+++ b/spec/classes/relationship__titles_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'relationships::titles' do
+  it { should compile }
+  it { should compile.with_all_deps }
+
+  it { should contain_file('/etc/svc') }
+  it { should contain_service('svc-title') }
+
+  it { should contain_file('/etc/svc').that_notifies('Service[svc-name]') }
+  it { should contain_file('/etc/svc').that_comes_before('Service[svc-name]') }
+  it { should contain_service('svc-title').that_requires('File[/etc/svc]') }
+  it { should contain_service('svc-title').that_subscribes_to('File[/etc/svc]') }
+end

--- a/spec/classes/relationship__titles_spec.rb
+++ b/spec/classes/relationship__titles_spec.rb
@@ -8,6 +8,7 @@ describe 'relationships::titles' do
 
   it { should contain_file('/etc/svc') }
   it { should contain_service('svc-title') }
+  it { should contain_service('svc-name') }
 
   it { should contain_file('/etc/svc').that_notifies('Service[svc-name]') }
   it { should contain_file('/etc/svc').that_comes_before('Service[svc-name]') }

--- a/spec/classes/relationship__titles_spec.rb
+++ b/spec/classes/relationship__titles_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'relationships::titles' do
+  let(:facts) { {:operatingsystem => 'Debian', :kernel => 'Linux'} }
+
   it { should compile }
   it { should compile.with_all_deps }
 

--- a/spec/fixtures/modules/relationships/manifests/titles.pp
+++ b/spec/fixtures/modules/relationships/manifests/titles.pp
@@ -1,0 +1,11 @@
+class relationships::titles {
+  file { "/etc/svc":
+    ensure => present,
+    notify => Service["svc-name"],
+  }
+
+  service { "svc-title":
+    ensure => running,
+    name   => "svc-name",
+  }
+}


### PR DESCRIPTION
As raised in #448, rspec-puppet doesn't properly handle resources where the title is different to the name.

This PR fixes the behaviour with a number of changes:
 * When using the `compile` matcher, an entry is added to the resource hash using the namevar (in addition to the existing entries for the aliases and title)
 * When calculating resource relationships, add references to the resources by the name (in addition to the existing references by title) to the results.
 * When compiling the catalogue, an alias is created in the catalogue so that the resource can be referred to by its name as well as its title

h/t to @domcleal for providing the test cases

Closes #448