### PR TITLE
(MODULES-4287) Make rspec-puppet tests platform independent

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -14,6 +14,8 @@ begin
 rescue LoadError
 end
 
+require 'rspec-puppet/monkey_patches'
+
 RSpec.configure do |c|
   c.add_setting :environmentpath, :default => '/etc/puppetlabs/code/environments'
   c.add_setting :module_path, :default => nil

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -58,6 +58,8 @@ RSpec.configure do |c|
     c.before :each do
       begin
         Puppet::Test::TestHelper.before_each_test
+      rescue Puppet::Context::DuplicateRollbackMarkError
+        Puppet::Test::TestHelper.send(:initialize_settings_before_each)
       rescue
       end
     end
@@ -76,5 +78,9 @@ RSpec.configure do |c|
       @adapter.setup_puppet(self)
       c.adapter = adapter
     end
+  end
+
+  c.before :each do |example|
+    stub_file_consts(example) if self.respond_to?(:stub_file_consts)
   end
 end

--- a/lib/rspec-puppet/example.rb
+++ b/lib/rspec-puppet/example.rb
@@ -13,7 +13,7 @@ RSpec::configure do |c|
   def c.rspec_puppet_include(group, type, file_path)
     escaped_file_path = Regexp.compile(file_path.join('[\\\/]'))
     if RSpec::Version::STRING < '3'
-      self.include group, :type => type, :example_group => { :file_path => escaped_file_path }
+      self.include group, :type => type, :example_group => { :file_path => escaped_file_path }, :spec_type => type
     else
       self.include group, :type => type, :file_path => lambda { |file_path, metadata| metadata[:type].nil? && escaped_file_path =~ file_path }
     end

--- a/lib/rspec-puppet/matchers/compile.rb
+++ b/lib/rspec-puppet/matchers/compile.rb
@@ -138,6 +138,7 @@ module RSpec::Puppet
       end
 
       def cycles_found?
+        Puppet::Type.suppress_provider
         cat = @catalogue.to_ral.relationship_graph
         cat.write_graph(:resources)
         if cat.respond_to? :find_cycles_in_graph
@@ -145,6 +146,8 @@ module RSpec::Puppet
         else
           find_cycles_legacy(cat)
         end
+        Puppet::Type.unsuppress_provider
+
         !@cycles.empty?
       end
 

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -294,6 +294,7 @@ module RSpec::Puppet
           end
         end
 
+        Puppet::Type.suppress_provider
         # Add autorequires if any
         if type == :require and resource.resource_type.respond_to? :eachautorequire
           resource.resource_type.eachautorequire do |t, b|
@@ -306,6 +307,8 @@ module RSpec::Puppet
             end
           end
         end
+        Puppet::Type.unsuppress_provider
+
         results.flatten
       end
 

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -1,0 +1,91 @@
+module Puppet
+  # Allow rspec-puppet to prevent Puppet::Type from automatically picking
+  # a provider for a resource. We need to do this because in order to fully
+  # resolve the graph edges, we have to convert the Puppet::Resource objects
+  # into Puppet::Type objects so that their autorequires are evaluated. We need
+  # to prevent provider code from being called during this process as it's very
+  # platform specific.
+  class Type
+    old_set_default = instance_method(:set_default)
+
+    define_method(:set_default) do |attr|
+      return if attr == :provider && self.class.suppress_provider?
+      old_set_default.bind(self).call(attr)
+    end
+
+    def self.suppress_provider?
+      @suppress_provider ||= false
+    end
+
+    def self.suppress_provider
+      @suppress_provider = true
+    end
+
+    def self.unsuppress_provider
+      @suppress_provider = false
+    end
+  end
+
+  # If Puppet::Node::Environment has a validate_dirs instance method (i.e.
+  # Puppet < 3.x), wrap the method to check if rspec-puppet is pretending to be
+  # running under windows. The original method uses Puppet::Util.absolute_path?
+  # (which in turn calls Puppet::Util::Platform.windows?) to validate the path
+  # to the manifests on disk during compilation, so we have to temporarily
+  # disable the pretending when running it.
+  class Node::Environment
+    if instance_methods.include?("validate_dirs")
+      old_validate_dirs = instance_method(:validate_dirs)
+
+      define_method(:validate_dirs) do |dirs|
+        pretending = false
+
+        if Puppet::Util::Platform.pretend_windows?
+          pretending = true
+          Puppet::Util::Platform.unpretend_windows
+        end
+
+        output = old_validate_dirs.bind(self).call(dirs)
+
+        Puppet::Util::Platform.pretend_windows if pretending
+
+        output
+      end
+    end
+  end
+
+  module Util
+    # Allow rspec-puppet to pretend to be windows.
+    module Platform
+      def windows?
+        pretend_windows? || !!File::ALT_SEPARATOR
+      end
+      module_function :windows?
+
+      def pretend_windows?
+        @pretend_windows ||= false
+      end
+      module_function :pretend_windows?
+
+      def pretend_windows
+        @pretend_windows = true
+      end
+      module_function :pretend_windows
+
+      def unpretend_windows
+        @pretend_windows = false
+      end
+      module_function :unpretend_windows
+    end
+  end
+end
+
+# Prevent Puppet from requiring 'puppet/util/windows' if we're pretending to be
+# windows, otherwise it will require other libraries that probably won't be
+# available on non-windows hosts.
+module Kernel
+  alias :old_require :require
+  def require(path)
+    return if path == 'puppet/util/windows' && Puppet::Util::Platform.pretend_windows?
+    old_require(path)
+  end
+end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -272,6 +272,19 @@ module RSpec::Puppet
     end
 
     def stub_facts!(facts)
+      if facts['operatingsystem'] && facts['operatingsystem'].to_s.downcase == 'windows'
+        # If we're not running in windows but are testing a catalogue destined
+        # for a windows host, pretend to be windows in the least awful way that
+        # I can think of.
+        unless Puppet::Util::Platform.windows?
+          Puppet::Util::Platform.pretend_windows
+          # On windows, puppet validates the value of the autosign setting as
+          # an absolute path unless it's disabled.
+          Puppet.settings[:autosign] = false
+        end
+      else
+        Puppet::Util::Platform.unpretend_windows
+      end
       facts.each { |k, v| Facter.add(k) { setcode { v } } }
     end
 

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -23,6 +23,56 @@ module RSpec::Puppet
       end
     end
 
+    def guess_type_from_path(path)
+      case path
+      when /spec\/defines/
+        :define
+      when /spec\/classes/
+        :class
+      when /spec\/functions/
+        :function
+      when /spec\/hosts/
+        :host
+      when /spec\/types/
+        :type
+      when /spec\/type_aliases/
+        :type_alias
+      when /spec\/provider/
+        :provider
+      when /spec\/applications/
+        :application
+      else
+        :unknown
+      end
+    end
+
+    def stub_file_consts(example)
+      if example.respond_to?(:metadata)
+        type = example.metadata[:type]
+      else
+        type = guess_type_from_path(example.example.metadata[:file_path])
+      end
+
+      munged_facts = facts_hash(nodename(type))
+
+      if munged_facts['operatingsystem'] && munged_facts['operatingsystem'].to_s.downcase == 'windows'
+        stub_const_wrapper('PATH_SEPARATOR', ';')
+        stub_const_wrapper('ALT_SEPARATOR', "\\")
+      else
+        stub_const_wrapper('PATH_SEPARATOR', ':')
+        stub_const_wrapper('ALT_SEPARATOR', nil)
+      end
+    end
+
+    def stub_const_wrapper(const, value)
+      if defined?(RSpec::Core::MockingAdapters::RSpec) && RSpec.configuration.mock_framework == RSpec::Core::MockingAdapters::RSpec
+        stub_const("File::#{const}", value)
+      else
+        File.send(:remove_const, const) if File.const_defined?(const)
+        File.const_set(const, value)
+      end
+    end
+
     def load_catalogue(type, exported = false, manifest_opts = {})
       with_vardir do
         node_name = nodename(type)
@@ -273,18 +323,11 @@ module RSpec::Puppet
 
     def stub_facts!(facts)
       if facts['operatingsystem'] && facts['operatingsystem'].to_s.downcase == 'windows'
-        # If we're not running in windows but are testing a catalogue destined
-        # for a windows host, pretend to be windows in the least awful way that
-        # I can think of.
-        unless Puppet::Util::Platform.windows?
-          Puppet::Util::Platform.pretend_windows
-          # On windows, puppet validates the value of the autosign setting as
-          # an absolute path unless it's disabled.
-          Puppet.settings[:autosign] = false
-        end
+        Puppet::Util::Platform.pretend_to_be :windows
       else
-        Puppet::Util::Platform.unpretend_windows
+        Puppet::Util::Platform.pretend_to_be :posix
       end
+      Puppet.settings[:autosign] = false
       facts.each { |k, v| Facter.add(k) { setcode { v } } }
     end
 

--- a/spec/classes/relationship__before_spec.rb
+++ b/spec/classes/relationship__before_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'relationships::before' do
+  let(:facts) { {:operatingsystem => 'debian'} }
   it { should contain_notify('foo').that_comes_before('Notify[bar]') }
   it { should contain_notify('foo').that_comes_before('Notify[baz]') }
   it { should contain_notify('bar').that_comes_before('Notify[baz]') }

--- a/spec/classes/test_provider_suitability_spec.rb
+++ b/spec/classes/test_provider_suitability_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'test::provider_suitability' do
+  [
+    {
+      :operatingsystem => 'Darwin',
+      :osfamily => 'Darwin',
+      :kernel => 'Darwin',
+    },
+    {
+      :operatingsystem => 'CentOS',
+      :osfamily => 'RedHat',
+      :kernel => 'Linux',
+    },
+    {
+      :operatingsystem => 'Solaris',
+      :osfamily => 'Solaris',
+      :kernel => 'SunOS',
+    },
+  ].each do |f|
+    context "On #{f[:operatingsystem]}" do
+      let(:facts) { f }
+
+      it { should compile.with_all_deps }
+      it { should contain_user('testuser') }
+    end
+  end
+end

--- a/spec/classes/test_windows_spec.rb
+++ b/spec/classes/test_windows_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'test::windows' do
+  let(:facts) { {:operatingsystem => 'windows' } }
+
+  it { should compile.with_all_deps }
+end

--- a/spec/fixtures/modules/test/manifests/provider_suitability.pp
+++ b/spec/fixtures/modules/test/manifests/provider_suitability.pp
@@ -1,0 +1,12 @@
+class test::provider_suitability {
+  $my_managehome = $::osfamily ? {
+    'Darwin' => 'false',
+    default  => true,
+  }
+
+  file { '/home': ensure => directory }
+  user { 'testuser':
+    managehome => $my_managehome,
+    home       => '/home/testuser',
+  }
+}

--- a/spec/fixtures/modules/test/manifests/windows.pp
+++ b/spec/fixtures/modules/test/manifests/windows.pp
@@ -1,0 +1,7 @@
+class test::windows {
+  file { 'C:\\test.txt':
+    content  => 'something',
+    ensure   => file,
+    provider => windows,
+  }
+}

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -17,16 +17,16 @@ describe RSpec::Puppet::Adapters::Base do
       it "sets the Puppet setting based on the example group setting" do
         context = double :confdir => "/etc/fingerpuppet"
         subject.set_setting(context, :confdir, :confdir)
-        expect(Puppet[:confdir]).to eq "/etc/fingerpuppet"
+        expect(Puppet[:confdir]).to match(%r{(C:)?/etc/fingerpuppet})
       end
 
       it "does not persist settings between example groups" do
         context1 = double :confdir => "/etc/fingerpuppet"
         context2 = double
         subject.set_setting(context1, :confdir, :confdir)
-        expect(Puppet[:confdir]).to eq "/etc/fingerpuppet"
+        expect(Puppet[:confdir]).to match(%r{(C:)?/etc/fingerpuppet})
         subject.set_setting(context2, :confdir, :confdir)
-        expect(Puppet[:confdir]).to eq "/etc/puppet"
+        expect(Puppet[:confdir]).to match(%r{(C:)?/etc/puppet})
       end
     end
 
@@ -37,7 +37,7 @@ describe RSpec::Puppet::Adapters::Base do
 
       it "sets the Puppet setting based on the global configuration value" do
         subject.set_setting(double, :confdir, :confdir)
-        expect(Puppet[:confdir]).to eq "/etc/bunraku"
+        expect(Puppet[:confdir]).to match(%r{(C:)?/etc/bunraku})
       end
     end
 
@@ -49,7 +49,7 @@ describe RSpec::Puppet::Adapters::Base do
       it "prefers the context specific setting" do
         context = double :confdir => "/etc/sockpuppet"
         subject.set_setting(context, :confdir, :confdir)
-        expect(Puppet[:confdir]).to eq "/etc/sockpuppet"
+        expect(Puppet[:confdir]).to match(%r{(C:)?/etc/sockpuppet})
       end
     end
 
@@ -147,7 +147,7 @@ describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 d
     it 'returns the configured environment manifest when set' do
       allow(RSpec.configuration).to receive(:manifest).and_return("/path/to/manifest")
       subject.setup_puppet(double(:environment => 'rp_puppet'))
-      expect(subject.manifest).to eq "/path/to/manifest"
+      expect(subject.manifest).to match(%r{(C:)?/path/to/manifest})
     end
 
     it 'returns nil when the configured environment manifest is not set' do

--- a/spec/unit/monkey_patches_spec.rb
+++ b/spec/unit/monkey_patches_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+# rspec 2.x doesn't have RSpec::Support, so fall back to File::ALT_SEPARATOR to
+# detect if running on windows
+WINDOWS = defined?(RSpec::Support) ? RSpec::Support::OS.windows? : !!File::ALT_SEPARATOR
+
+describe 'File constants' do
+  context 'on windows', :if => WINDOWS do
+    specify('PATH_SEPARATOR') { expect(File::PATH_SEPARATOR).to eq(';') }
+    specify('ALT_SEPARATOR') { expect(File::ALT_SEPARATOR).to eq("\\") }
+  end
+
+  context 'on posix', :unless => WINDOWS do
+    specify('PATH_SEPARATOR') { expect(File::PATH_SEPARATOR).to eq(':') }
+    specify('ALT_SEPARATOR') { expect(File::ALT_SEPARATOR).to be_nil }
+  end
+end


### PR DESCRIPTION
In order to fully resolve the graph and create all the automatic relationships we have to convert the resource catalogue produced by the compiler into a RAL catalogue like that which an agent would apply.

An unfortunate side effect of this is that it causes providers to be loaded and tested for suitability. This can cause problems for people who have manifests that specify providers for platforms other than the one they're running rspec-puppet on (e.g. testing Windows manifests on a Linux host).

This PR adds a few monkey patches make this possible:

 * `Puppet::Type#set_default` has been modified so that we can prevent Puppet from assigning a default provider when performing catalogue tests (but not when testing the types themselves).
 * `Puppet::Util::Platform.windows?` has been modified so that can force Puppet to pretend that it's running on windows, allowing the windows specific parameter validations to succeed.
 * `Kernel.require` has been modified to prevent Puppet from requiring `puppet/util/windows` if Puppet is pretending to be running on windows in order to prevent it from requiring other libraries that generally aren't installed on non-windows hosts.
 * `Puppet::Node::Environment#validate_dirs` (if it exists, which it only does on Puppet < 3.x) has been wrapped to disable the windows pretending (if we're pretending) while the method is running as this is used by the compiler to determine if the paths on disk to the manifests is valid.

This PR supercedes #481

Closes #175 #192 #256 #352 #376 #387 #437