### PR TITLE
Handle resources with identical namevars but unique titles

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -250,13 +250,7 @@ module RSpec::Puppet
         )
       end
 
-      cat = adapter.catalog(node_obj, exported)
-      cat.resources.each do |resource|
-        if resource.uniqueness_key != [resource.title]
-          cat.alias(resource, resource.uniqueness_key.first)
-        end
-      end
-      cat
+      adapter.catalog(node_obj, exported)
     end
 
     def stub_facts!(facts)

--- a/spec/classes/relationship__titles_spec.rb
+++ b/spec/classes/relationship__titles_spec.rb
@@ -8,7 +8,6 @@ describe 'relationships::titles' do
 
   it { should contain_file('/etc/svc') }
   it { should contain_service('svc-title') }
-  it { should contain_service('svc-name') }
 
   it { should contain_file('/etc/svc').that_notifies('Service[svc-name]') }
   it { should contain_file('/etc/svc').that_comes_before('Service[svc-name]') }

--- a/spec/classes/test_duplicate_alias_spec.rb
+++ b/spec/classes/test_duplicate_alias_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'test::duplicate_alias' do
+  it { should compile }
+end

--- a/spec/classes/test_duplicate_alias_spec.rb
+++ b/spec/classes/test_duplicate_alias_spec.rb
@@ -2,4 +2,7 @@ require 'spec_helper'
 
 describe 'test::duplicate_alias' do
   it { should compile }
+  it { should contain_exec('foo_bar_1') }
+  it { should contain_exec('foo_bar_2') }
+  it { should_not contain_exec('/bin/echo foo bar') }
 end

--- a/spec/fixtures/modules/test/manifests/duplicate_alias.pp
+++ b/spec/fixtures/modules/test/manifests/duplicate_alias.pp
@@ -1,0 +1,9 @@
+class test::duplicate_alias {
+  exec { 'foo_bar_1':
+    command => '/bin/echo foo bar',
+  }
+
+  exec { 'foo_bar_2':
+    command => '/bin/echo foo bar',
+  }
+}


### PR DESCRIPTION
As raised in #499, the change introduced in #496 broke support for cases where resources of the same type have the same value in their namevar parameter but have unique titles to prevent duplicate resource declaration. This was due to the way we used resource aliases in the catalogue to handle the issue of resources where title != namevar.

This PR changes the behaviour to remove the resource aliases and instead change the resource lookup logic to fallback to iterating through all the resources in the catalogue of the requested type and checking their namevars.

I've also removed the test from the `relationships::titles` class where we were allowing users to do the initial search for the resource by namevar instead of title (functionality that was only introduced in #496 and not part of any release). In my opinion, you should test for the presence of the resource (`contain_service('foo')`) by the title you gave it in the manifest. If there are strong feelings against this though, it wouldn't be hard to reimplement.

Closes #499