### PR TITLE
Fixture resources from create_resources() and coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,13 @@ RSpec.configure do |c|
 end
 ```
 
+Resources declared outside of the module being tested (i.e. forge dependencies)
+are automatically removed from the coverage report. There is one exception for
+this though: **prior to Puppet 4.6.0**, resources created by functions
+(create\_resources(), ensure\_package(), etc) did not have the required
+information in them to determine which manifest they came from and so can not
+be excluded from the coverage report.
+
 ## Related projects
 
 * [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec_helper): shared spec helpers to setup puppet

--- a/spec/classes/test_api_spec.rb
+++ b/spec/classes/test_api_spec.rb
@@ -10,15 +10,26 @@ describe 'test::bare_class' do
       expect(subject.call).to be_a(Puppet::Resource::Catalog)
     end
 
-    it 'should be included in the coverage filter' do
-      expect(RSpec::Puppet::Coverage.filters).to include('Class[Test::Bare_class]')
-    end
-
     describe 'derivative group' do
       subject { catalogue.resource('Notify', 'foo') }
 
       it 'can redefine subject' do
         expect(subject).to be_a(Puppet::Resource)
+      end
+    end
+  end
+
+  describe 'coverage' do
+    it 'class should be included in the coverage filter' do
+      expect(RSpec::Puppet::Coverage.filters).to include('Class[Test::Bare_class]')
+    end
+
+    # file and line information was only added to resources created with
+    # ensure_resource() in 4.6.0 (PUP-6530).
+    if Puppet::Util::Package.versioncmp(Puppet.version, '4.6.0') >= 0
+      it 'should not include resources from other modules created with create_resources()' do
+        expect(RSpec::Puppet::Coverage.instance.results[:resources]).to_not include('Notify[create_resources notify]')
+        expect(subject).to contain_notify('create_resources notify')
       end
     end
   end

--- a/spec/fixtures/modules/dynamic/manifests/create_resources.pp
+++ b/spec/fixtures/modules/dynamic/manifests/create_resources.pp
@@ -1,0 +1,3 @@
+class dynamic::create_resources {
+  create_resources('notify', {'create_resources notify' => {}})
+}

--- a/spec/fixtures/modules/test/manifests/bare_class.pp
+++ b/spec/fixtures/modules/test/manifests/bare_class.pp
@@ -1,3 +1,4 @@
 class test::bare_class {
   notify { 'foo': }
+  include dynamic::create_resources
 }


### PR DESCRIPTION
As raised in #364, resources created using functions like `create_resources()` in dependencies were showing up in coverage reports. rspec-puppet automatically removes resources declared in dependencies from the coverage report based on the names of the manifest files that the resources were declared in, but unfortunately prior to Puppet 4.6.0 the file and line information wasn't added to resources created by `create_resource()` (see [PUP-6530](https://tickets.puppetlabs.com/browse/PUP-6530).

This PR adds a spec to ensure that we are removing fixture resources created by functions on Puppet >= 4.6.0 and adds a section to the coverage report documentation in the README explaining why these resources aren't excluded if the user is running Puppet < 4.6.0.

Closes #364