### PR TITLE
Set Puppet settings as application defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,151 @@ RSpec.configure do |c|
 end
 ```
 
+## Configuration
+
+rspec-puppet can be configured by modifying the `RSpec.configure` block in your
+`spec/spec_helper.rb` file.
+
+```
+RSpec.configure do |c|
+  c.<config option> = <value>
+end
+```
+
+#### manifest\_dir
+Type   | Default  | Puppet Version(s)
+------ | -------- | -----------------
+String | Required | 2.x, 3.x
+
+The path to the directory containing your basic manifests like `site.pp`.
+
+#### module\_path
+Type   | Default  | Puppet Version(s)
+------ | -------- | -----------------
+String | Required | 2.x, 3.x, 4.x
+
+The path to the directory containing your Puppet modules.
+
+#### default\_facts
+Type | Default | Puppet Version(s)
+---- | ------- | -----------------
+Hash | `{}`    | 2.x, 3.x, 4.x
+
+A hash of default facts that should be used for all the tests.
+
+#### hiera\_config
+Type   | Default       | Puppet Version(s)
+------ | ------------- | -----------------
+String | `"/dev/null"` | 3.x, 4.x
+
+The path to your `hiera.yaml` file (if used).
+
+#### default\_node\_params
+Type | Default | Puppet Version(s)
+---- | ------- | -----------------
+Hash | `{}`    | 4.x
+
+A hash of default node parameters that should be used for all the tests.
+
+#### default\_trusted\_facts
+Type | Default | Puppet Version(s)
+---- | ------- | -----------------
+Hash | `{}`    | 4.x
+
+A hash of default trusted facts that should be used for all the tests
+(available in the manifests as the `$trusted` hash). In order to use this, the
+`trusted_node_data` setting must be set to `true`.
+
+#### trusted\_node\_data
+Type    | Default | Puppet Version(s)
+------- | ------- | -----------------
+Boolean | `false` | 3.x, 4.x
+
+Configures rspec-puppet to use the `$trusted` hash when compiling the
+catalogues.
+
+#### confdir
+Type   | Default         | Puppet Version(s)
+------ | --------------- | -----------------
+String | `"/etc/puppet"` | 2.x, 3.x, 4.x
+
+The path to the main Puppet configuration directory.
+
+#### config
+Type   | Default                | Puppet Version(s)
+------ | ---------------------- | -----------------
+String | Puppet's default value | 2.x, 3.x, 4.x
+
+The path to `puppet.conf`.
+
+#### manifest
+Type   | Default                | Puppet Version(s)
+------ | ---------------------- | -----------------
+String | Puppet's default value | 2.x, 3.x
+
+The entry-point manifest for Puppet, usually `$manifest_dir/site.pp`.
+
+#### template\_dir
+Type   | Default | Puppet Version(s)
+------ | ------- | -----------------
+String | `nil`   | 2.x, 3.x
+
+The path to the directory that Puppet should search for templates that are
+stored outside of modules.
+
+#### environmentpath
+Type   | Default                               | Puppet Version(s)
+------ | ------------------------------------- | -----------------
+String | `"/etc/puppetlabs/code/environments"` | 4.x
+
+The search path for environment directories.
+
+#### parser
+Type   | Default     | Puppet Version(s)
+------ | ----------- | -----------------
+String | `"current"` | 3.x
+
+This switches between the 3.x (`current`) and 4.x (`future`) parsers.
+
+#### ordering
+Type   | Default        | Puppet Version(s)
+------ | -------------- | -----------------
+String | `"title-hash"` | 3.x, 4.x
+
+How unrelated resources should be ordered when applying a catalogue.
+ * `manifest` - Use the order in which the resources are declared in the
+   manifest.
+ * `title-hash` - Order the resources randomly, but in a consistent manner
+   across runs (the order will only change if the manifest changes).
+ * `random` - Order the resources randomly.
+
+#### strict\_variables
+Type    | Default | Puppet Version(s)
+------- | ------- | -----------------
+Boolean | `false` | 3.x, 4.x
+
+Makes Puppet raise an error when it tries to reference a variable that hasn't
+been defined (not including variables that have been explicitly set to
+`undef`).
+
+#### stringify\_facts
+Type    | Default | Puppet Version(s)
+------- | ------- | -----------------
+Boolean | `true`  | 3.x, 4.x
+
+Makes rspec-puppet coerce all the fact values into strings (matching the
+behaviour of older versions of Puppet).
+
+#### enable\_pathname\_stubbing
+Type    | Default | Puppet Version(s)
+------- | ------- | -----------------
+Boolean |`false`  | 2.x, 3.x, 4.x
+
+Configures rspec-puppet to stub out `Pathname#absolute?` with it's own
+implementation. This should only be enabled if you're running into an issue
+running cross-platform tests where you have Ruby code (types, providers,
+functions, etc) that use `Pathname#absolute?`.
+
 ## Naming conventions
 
 For clarity and consistency, I recommend that you use the following directory

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 require 'rspec-puppet/adapters'
 
+def context_double(options = {})
+  double({:environment => 'rp_puppet'}.merge(options))
+end
+
 describe RSpec::Puppet::Adapters::Base do
   describe '#setup_puppet' do
     it "sets up all settings listed in the settings map" do
-      context = double :environment => 'rp_puppet'
-      subject.settings_map.each do |puppet_setting, rspec_setting|
-        expect(subject).to receive(:set_setting).with(context, puppet_setting, rspec_setting)
-      end
+      context = context_double
+      expected_settings = Hash[*subject.settings_map.map { |r| [r.first, anything] }.flatten]
+      expect(Puppet.settings).to receive(:initialize_app_defaults).with(hash_including(expected_settings))
       subject.setup_puppet(context)
     end
   end
@@ -15,17 +18,17 @@ describe RSpec::Puppet::Adapters::Base do
   describe '#set_setting' do
     describe "with a context specific setting" do
       it "sets the Puppet setting based on the example group setting" do
-        context = double :confdir => "/etc/fingerpuppet"
-        subject.set_setting(context, :confdir, :confdir)
+        context = context_double :confdir => "/etc/fingerpuppet"
+        subject.setup_puppet(context)
         expect(Puppet[:confdir]).to match(%r{(C:)?/etc/fingerpuppet})
       end
 
       it "does not persist settings between example groups" do
-        context1 = double :confdir => "/etc/fingerpuppet"
-        context2 = double
-        subject.set_setting(context1, :confdir, :confdir)
+        context1 = context_double :confdir => "/etc/fingerpuppet"
+        context2 = context_double
+        subject.setup_puppet(context1)
         expect(Puppet[:confdir]).to match(%r{(C:)?/etc/fingerpuppet})
-        subject.set_setting(context2, :confdir, :confdir)
+        subject.setup_puppet(context2)
         expect(Puppet[:confdir]).to match(%r{(C:)?/etc/puppet})
       end
     end
@@ -36,7 +39,7 @@ describe RSpec::Puppet::Adapters::Base do
       end
 
       it "sets the Puppet setting based on the global configuration value" do
-        subject.set_setting(double, :confdir, :confdir)
+        subject.setup_puppet(context_double)
         expect(Puppet[:confdir]).to match(%r{(C:)?/etc/bunraku})
       end
     end
@@ -47,8 +50,8 @@ describe RSpec::Puppet::Adapters::Base do
       end
 
       it "prefers the context specific setting" do
-        context = double :confdir => "/etc/sockpuppet"
-        subject.set_setting(context, :confdir, :confdir)
+        context = context_double :confdir => "/etc/sockpuppet"
+        subject.setup_puppet(context)
         expect(Puppet[:confdir]).to match(%r{(C:)?/etc/sockpuppet})
       end
     end
@@ -61,11 +64,11 @@ describe RSpec::Puppet::Adapters::Base do
   end
 end
 
-describe RSpec::Puppet::Adapters::Adapter3X do
+describe RSpec::Puppet::Adapters::Adapter3X, :if => (3.0 ... 4.0).include?(Puppet.version.to_f) do
 
   let(:test_context) { double :environment => 'rp_env' }
 
-  context 'when running on puppet 3.5 or later', :if => Puppet.version.to_f >= 3.5 do
+  context 'when running on puppet 3.5 or later', :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
     it 'sets Puppet[:strict_variables] to false by default' do
       subject.setup_puppet(test_context)
       expect(Puppet[:strict_variables]).to eq(false)


### PR DESCRIPTION
Instead of configuring Puppet by calling `Puppet::Settings#[]=`, get the values set in `RSpec.configure` or from the example group and use them to set the application_default values for the settings instead.

This will allow us to effectively have setting lookup priority of:
 - Some value set by calling `Puppet::Settings#[]=`
 - Some value set using `let(<setting) {}` in the example
 - The value set in `RSpec.configure`
 - The default value from Puppet.

This way if users choose to configure Puppet directly, their settings will not be overwritten and new releases that introduce new settings won't break any existing tests as `Puppet.settings[:whatever] = 'something'` will always take precedence.

Fixes #307