### PR TITLE
Adjust facts handling to only downcase fact names in facts hash

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -144,7 +144,11 @@ module RSpec::Puppet
       end
 
       facts_val.merge!(munge_facts(facts)) if self.respond_to?(:facts)
-      facts_val
+
+      # Facter currently supports lower case facts.  Bug FACT-777 has been submitted to support case sensitive
+      # facts.
+      downcase_facts = Hash[facts_val.map { |k, v| [k.downcase, v] }]
+      downcase_facts
     end
 
     def param_str(params)
@@ -263,11 +267,9 @@ module RSpec::Puppet
       end
     end
 
-    # Facter currently supports lower case facts.  Bug FACT-777 has been submitted to support case sensitive
-    # facts.
     def munge_facts(facts)
       return facts.reduce({}) do | memo, (k, v)|
-        memo.tap { |m| m[k.to_s.downcase] = munge_facts(v) }
+        memo.tap { |m| m[k.to_s] = munge_facts(v) }
       end if facts.is_a? Hash
 
       return facts.reduce([]) do |memo, v|

--- a/spec/classes/facts_spec.rb
+++ b/spec/classes/facts_spec.rb
@@ -36,8 +36,8 @@ describe 'structured_facts::hash' do
   # See note concerning mixed case in facts at the beginning of the file
   context 'mixed case symbols in facts', :if => Puppet.version.to_f >= 4.0 do
     let(:facts) {{
-      :os => {
-        :FaMiLy => family
+      :oS => {
+        :family => family
       }
     }}
 
@@ -63,8 +63,8 @@ describe 'structured_facts::hash' do
   # See note concerning mixed case in facts at the beginning of the file
   context 'mixed case strings in facts', :if => Puppet.version.to_f >= 4.0 do
     let(:facts) {{
-      'os' => {
-        'FaMiLy' => family
+      'oS' => {
+        'family' => family
       }
     }}
 
@@ -106,8 +106,8 @@ describe 'structured_facts::top_scope' do
   # See note concerning mixed case in facts at the beginning of the file
   context 'mixed case in facts' do
     let(:facts) {{
-      :os => {
-        :FaMiLy => family
+      :Os => {
+        :family => family
       }
     }}
 
@@ -133,8 +133,8 @@ describe 'structured_facts::top_scope' do
   # See note concerning mixed case in facts at the beginning of the file
   context 'mixed case in facts' do
     let(:facts) {{
-      'os' => {
-        'FaMiLy' => family
+      'Os' => {
+        'family' => family
       }
     }}
 
@@ -142,5 +142,20 @@ describe 'structured_facts::top_scope' do
     it { should compile.with_all_deps }
 
     it { should contain_notify(family) }
+  end
+end
+
+describe 'structured_facts::case_check' do
+  context 'mixed case in structure fact nested keys', :if => Puppet.version.to_f >= 4.0 do
+    let(:facts) {{
+      'custom_fact' => {
+        'MixedCase' => 'value'
+      }
+    }}
+
+    it { should contain_class('structured_facts::case_check') }
+    it { should compile.with_all_deps }
+
+    it { should contain_notify('value') }
   end
 end

--- a/spec/fixtures/modules/structured_facts/manifests/case_check.pp
+++ b/spec/fixtures/modules/structured_facts/manifests/case_check.pp
@@ -1,0 +1,4 @@
+class structured_facts::case_check {
+  $_value = $facts['custom_fact']['MixedCase']
+  notify { "$_value": }
+}


### PR DESCRIPTION
Only the top-level keys, corresponding to the fact names, in the
facts hash should be downcased. Puppet leaves any keys as part
of a hash returned from a structured fact in the original case.