### PR TITLE
Fix canonicalize_resource to only match resources with same namevar

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -260,7 +260,7 @@ module RSpec::Puppet
             type == resource.type
           }.map { |type, name|
             @catalogue.resource(type, name)
-          }.first { |cat_res|
+          }.find { |cat_res|
             cat_res.builtin_type? && cat_res.uniqueness_key.first == resource.title
           }
         end

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -260,7 +260,7 @@ module RSpec::Puppet
             type == resource.type
           }.map { |type, name|
             @catalogue.resource(type, name)
-          }.find { |cat_res|
+          }.compact.find { |cat_res|
             cat_res.builtin_type? && cat_res.uniqueness_key.first == resource.title
           }
         end

--- a/spec/classes/relationship__before_spec.rb
+++ b/spec/classes/relationship__before_spec.rb
@@ -15,6 +15,9 @@ describe 'relationships::before' do
   it { should contain_notify('bar').that_requires(['Notify[foo]']) }
   it { should contain_notify('baz').that_requires(['Notify[foo]','Notify[bar]']) }
 
+  it { should contain_class('relationship::before::pre').that_comes_before('Class[relationship::before::post]') }
+  it { should contain_class('relationship::before::post').that_requires('Class[relationship::before::pre]') }
+
   it { should contain_notify('pre').that_comes_before(['Notify[post]']) }
   it { should contain_notify('post').that_requires(['Notify[pre]']) }
 
@@ -33,4 +36,7 @@ describe 'relationships::before' do
   it { should_not contain_notify('foo').that_requires('Notify[unknown]') }
   it { should_not contain_notify('bar').that_requires('Notify[unknown]') }
   it { should_not contain_notify('baz').that_requires('Notify[unknown]') }
+
+  it { should_not contain_class('relationship::before::pre').that_comes_before('Class[relationship::before::unknown]') }
+  it { should_not contain_class('relationship::before::post').that_requires('Class[relationship::before::unknown]') }
 end

--- a/spec/classes/relationship__before_spec.rb
+++ b/spec/classes/relationship__before_spec.rb
@@ -25,4 +25,12 @@ describe 'relationships::before' do
   it { should contain_notify('qux').that_requires(['File[/tmp/foo]']) }
   it { should contain_notify('bazz').that_comes_before(['Notify[qux]']) }
   it { should contain_notify('qux').that_requires(['Notify[bazz]']) }
+
+  it { should_not contain_notify('foo').that_comes_before('Notify[unknown]') }
+  it { should_not contain_notify('bar').that_comes_before('Notify[unknown]') }
+  it { should_not contain_notify('baz').that_comes_before('Notify[unknown]') }
+
+  it { should_not contain_notify('foo').that_requires('Notify[unknown]') }
+  it { should_not contain_notify('bar').that_requires('Notify[unknown]') }
+  it { should_not contain_notify('baz').that_requires('Notify[unknown]') }
 end


### PR DESCRIPTION
9341e04f introduced a regression when using matchers to check that a
resource reference doesn't exist, as the matcher will find a resource of
the same type but with a different namevar/title.

The following example would fail if any `Bar` resource exists, as the
title in the `Bar[unknown]` resource reference would be ignored:

    is_expected.not_to contain_foo("foo").that_requires("Bar[unknown]")

The method passed a block to #first rather than #find in order to filter
by the namevar, but the block is unused.

---

Fix nil error for irretrievable `Class[main]` resource

When iterating over `@catalogue.resource_keys`, a builtin `Class[main]`
resource is returned, but isn't accessible through `#resource`, causing
a nil entry in the list of matched resources. The array of resources is
now compacted to remove inaccessible builtin resources, which fixes an
error when using `Class` resources in relationship matchers.