### PR TITLE
let(:node) now overrides existing facts rather than vice versa

### DIFF
--- a/spec/classes/test_basic_spec.rb
+++ b/spec/classes/test_basic_spec.rb
@@ -2,4 +2,17 @@ require 'spec_helper'
 
 describe 'test::basic' do
   it { should contain_fake('foo').with_three([{'foo' => 'bar'}]) }
+
+  context 'testing node based facts' do
+    let(:pre_condition) { 'notify { $::fqdn: }' }
+    let(:node) { 'test123.test.com' }
+    let(:facts) do
+      {
+        :fqdn => 'notthis.test.com',
+      }
+    end
+
+    it { should contain_notify('test123.test.com') }
+    it { should_not contain_notify('notthis.test.com') }
+  end
 end


### PR DESCRIPTION
Addresses issue 509 by reversing the priority of merged facts hashes