### PR TITLE
Support setting node parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,29 @@ end
 Any facts you provide with `let(:facts)` in a spec will automatically be merged on top
 of the default facts.
 
+#### Specifying top-scope variables that should be available to your manifest
+
+You can create top-scope variables much in the same way as an ENC.
+
+
+```ruby
+let(:node_params) { { :hostgroup => 'webservers', :rack => 'KK04', :status => 'maintenance' } }
+```
+
+You can also create a set of default top-scope variables provided to all specs in your spec_helper:
+
+``` ruby
+RSpec.configure do |c|
+  c.default_node_params = {
+    :owner => 'itprod',
+    :site => 'ams4',
+    :status => 'live'
+  }
+end
+```
+
+**NOTE** Setting top-scope variables is not supported in Puppet < 3.0.
+
 #### Specifying extra code to load (pre-conditions)
 
 If the manifest being tested relies on another class or variables to be set, these can be added via

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -23,6 +23,7 @@ RSpec.configure do |c|
   c.add_setting :config, :default => nil
   c.add_setting :confdir, :default => '/etc/puppet'
   c.add_setting :default_facts, :default => {}
+  c.add_setting :default_node_params, :default => {}
   c.add_setting :default_trusted_facts, :default => {}
   c.add_setting :hiera_config, :default => '/dev/null'
   c.add_setting :parser, :default => 'current'

--- a/spec/classes/node_params_spec.rb
+++ b/spec/classes/node_params_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'node_params', :if => Puppet::Util::Package.versioncmp(Puppet.version, '3.0.0') >= 0 do
+  fuzzed = {
+    :string => 'foo bar baz',
+    :hash => { 'foo' => 'bar', 'baz' => 'foo' },
+    :array => %w[baz foo bar],
+    :true => true,
+    :false => false,
+    :integer => 5,
+    :float => 4.4,
+    :nil => nil
+  }
+
+  let(:node_params) { fuzzed }
+
+  it 'compiles into a catalogue without dependency cycles' do
+    is_expected.to compile.with_all_deps
+    is_expected.to contain_class('node_params')
+  end
+
+  fuzzed.each do |title, message|
+    it "contains Notify[#{title}] with message => #{message}" do
+      is_expected.to contain_notify(title.to_s).with(:message => message)
+    end
+  end
+end

--- a/spec/classes/node_params_spec.rb
+++ b/spec/classes/node_params_spec.rb
@@ -24,4 +24,8 @@ describe 'node_params', :if => Puppet::Util::Package.versioncmp(Puppet.version, 
       is_expected.to contain_notify(title.to_s).with(:message => message)
     end
   end
+
+  it "doesn't leak to the facts hash", :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0 do
+    is_expected.to contain_notify('stringfact').with(:message => '')
+  end
 end

--- a/spec/fixtures/modules/node_params/manifests/init.pp
+++ b/spec/fixtures/modules/node_params/manifests/init.pp
@@ -3,6 +3,12 @@ class node_params {
     message => $::string,
   }
 
+  if $facts { # protect against puppet 3 not having $facts hash
+    notify { 'stringfact':
+      message => "${facts['string']}",
+    }
+  }
+
   notify { 'hash':
     message => $::hash,
   }

--- a/spec/fixtures/modules/node_params/manifests/init.pp
+++ b/spec/fixtures/modules/node_params/manifests/init.pp
@@ -1,0 +1,33 @@
+class node_params {
+  notify { 'string':
+    message => $::string,
+  }
+
+  notify { 'hash':
+    message => $::hash,
+  }
+
+  notify { 'array':
+    message => $::array,
+  }
+
+  notify { 'true':
+    message => $::true,
+  }
+
+  notify { 'false':
+    message => $::false,
+  }
+
+  notify { 'integer':
+    message => $::integer,
+  }
+
+  notify { 'float':
+    message => $::float,
+  }
+
+  notify { 'nil':
+    message => $::nil,
+  }
+}


### PR DESCRIPTION
This commit adds a support for setting a node's parameters. It adds a
new helper, :node_params, that is a hash with members that are passed to
the instantiated node object to become its top-scope parameters.

Currently the only ways to set top scope parameters in an example is to
specify them as facts (which isn't technically really correct and also sets
the same values in the facts hash) or set them as a :pre_condition which,
as a string, is a pain to work with when you'd like to override things
in individual examples.

Adding support for :node_params, makes it possible to set top-scope
variables for a node the same way you would when using an ENC.