### PR TITLE
Reverts fixtures symlink cleanup in after suite hook

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -39,10 +39,6 @@ RSpec.configure do |c|
     RSpec::Puppet::Setup.safe_setup_directories(nil, false)
   end
 
-  c.after(:all) do
-    RSpec::Puppet::Setup.safe_teardown_links
-  end
-
   if defined?(Puppet::Test::TestHelper)
     begin
       Puppet::Test::TestHelper.initialize


### PR DESCRIPTION
As reported in #526, automatically cleaning up the fixtures link at the end of the suite run breaks the ability to run the tests in parallel.

Closes #526