### PR TITLE
Render resource titles individually instead of using Object#inspect

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -149,10 +149,15 @@ module RSpec::Puppet
           raise ArgumentError, "You need to provide params for an application"
         end
       elsif type == :define
+        title_str = if title.is_a?(Array)
+                      '[' + title.map { |r| "'#{r}'" }.join(', ') + ']'
+                    else
+                      "'#{title}'"
+                    end
         if opts.has_key?(:params)
-          "#{class_name} { #{title.inspect}: #{param_str(opts[:params])} }"
+          "#{class_name} { #{title_str}: #{param_str(opts[:params])} }"
         else
-          "#{class_name} { #{title.inspect}: }"
+          "#{class_name} { #{title_str}: }"
         end
       elsif type == :host
         nil

--- a/spec/defines/test_loop_define_spec.rb
+++ b/spec/defines/test_loop_define_spec.rb
@@ -1,10 +1,18 @@
 require 'spec_helper'
 
 describe 'test::loop_define' do
-  let(:title) { ['a', 'b'] }
+  context 'with an array of plain strings' do
+    let(:title) { ['a', 'b'] }
 
-  context 'both sub resources in the catalogue' do
-    it { should contain_package('a') }
-    it { should contain_package('b') }
+    context 'both sub resources in the catalogue' do
+      it { should contain_package('a') }
+      it { should contain_package('b') }
+    end
+  end
+
+  context 'with a title containing a $' do
+    let(:title) { '$test' }
+
+    it { should compile }
   end
 end


### PR DESCRIPTION
This leads to problems like #536 where the resource title contains a $ which
Puppet then tries to interpolate due to the double quotes.

Fixes #536