### PR TITLE
Fix race condition on mkdir and symlink under parallel tests

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -97,7 +97,11 @@ module RSpec::Puppet
           $stderr.puts "!! #{dir} already exists and is not a directory"
         end
       else
-        FileUtils.mkdir dir
+        begin
+          FileUtils.mkdir dir
+        rescue Errno::EEXIST => e
+          raise e unless File.directory? dir
+        end
         puts " + #{dir}/" if verbose
       end
     end
@@ -145,7 +149,11 @@ module RSpec::Puppet
             abort
           end
         else
-          FileUtils.ln_s(File.expand_path(source), target)
+          begin
+            FileUtils.ln_s(File.expand_path(source), target)
+          rescue Errno::EEXIST => e
+            raise e unless File.symlink?(target) && File.readlink(target) == File.expand_path(source)
+          end
         end
         puts " + #{target}" if verbose
       end


### PR DESCRIPTION
This PR fixes a race condition that we experienced because we run rspec-puppet tests parallelized. Without this fix we were periodically running into cases where this would happen:

- process 1 would notice that a directory is missing
- process 2 would notice that a directory is missing
- process 1 would create the directory ✅ 
- process 2 would create the directory and get Errno::EEXIST 🚫

The change here disregards the `Errno::EEXIST` for directories and symlinks, when the directory or symlink that's being created already exists and is proper.