### PR TITLE
Add 'setup_fixtures' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ implementation. This should only be enabled if you're running into an issue
 running cross-platform tests where you have Ruby code (types, providers,
 functions, etc) that use `Pathname#absolute?`.
 
+#### setup\_fixtures
+Type    | Default | Puppet Version(s)
+------- | ------- | ---------------
+Boolean | `true`  | 2.x, 3.x, 4.x
+
+Configures rspec-puppet to automatically create a link from the root of your
+module to `spec/fixtures/<module name>` at the beginning of the test run.
+
 ## Naming conventions
 
 For clarity and consistency, I recommend that you use the following directory

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -38,9 +38,12 @@ RSpec.configure do |c|
   c.add_setting :stringify_facts, :default => true
   c.add_setting :strict_variables, :default => false
   c.add_setting :adapter
+  c.add_setting :setup_fixtures, :default => true
 
   c.before(:all) do
-    RSpec::Puppet::Setup.safe_setup_directories(nil, false)
+    if RSpec.configuration.setup_fixtures?
+      RSpec::Puppet::Setup.safe_setup_directories(nil, false)
+    end
   end
 
   if defined?(Puppet::Test::TestHelper)


### PR DESCRIPTION
When using a modulepath that already satisfies the correct structure, the call to `RSpec::Puppet::Setup.safe_setup_directories` emits the 'Unable to determine module name.' error message despite the specs continuing to run correctly.

This adds a configuration option to disable the default fixtures setup.