### PR TITLE
Don't clobber the existing networking facts hash

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -214,11 +214,12 @@ module RSpec::Puppet
         'fqdn'          => node,
         'domain'        => node.split('.', 2).last,
         'clientcert'    => node,
-        'networking'    => {
-          'fqdn'          => node,
-          'domain'        => node.split('.', 2).last,
-          'hostname'      => node.split('.').first
-        }
+      }
+
+      networking_facts = {
+        'hostname' => node_facts['hostname'],
+        'fqdn'     => node_facts['fqdn'],
+        'domain'   => node_facts['domain'],
       }
 
       result_facts = if RSpec.configuration.default_facts.any?
@@ -230,6 +231,8 @@ module RSpec::Puppet
       result_facts.merge!(munge_facts(base_facts))
       result_facts.merge!(munge_facts(facts)) if self.respond_to?(:facts)
       result_facts.merge!(munge_facts(node_facts))
+
+      (result_facts['networking'] ||= {}).merge!(networking_facts)
 
       # Facter currently supports lower case facts.  Bug FACT-777 has been submitted to support case sensitive
       # facts.

--- a/spec/classes/test_basic_spec.rb
+++ b/spec/classes/test_basic_spec.rb
@@ -8,11 +8,21 @@ describe 'test::basic' do
     let(:node) { 'test123.test.com' }
     let(:facts) do
       {
-        :fqdn => 'notthis.test.com',
+        :fqdn       => 'notthis.test.com',
+        :networking => {
+          :primary => 'eth0',
+        },
       }
     end
 
     it { should contain_notify('test123.test.com') }
     it { should_not contain_notify('notthis.test.com') }
+
+    context 'existing networking facts should not be clobbered', :if => Puppet.version.to_f >= 4.0 do
+      let(:pre_condition) { 'notify { [$facts["networking"]["primary"], $facts["networking"]["hostname"]]: }' }
+
+      it { should contain_notify('eth0') }
+      it { should contain_notify('test123') }
+    end
   end
 end


### PR DESCRIPTION
Merge the node name derived facts into the networking fact hash so as not to clobber any existing values that might be in the networking fact hash.

Fixes #547