### PR TITLE
Stub out Puppet::Confine::Exists#pass?

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -111,6 +111,20 @@ module Puppet
       module_function :pretend_platform
     end
   end
+
+  if defined?(Puppet::Confine)
+    class Confine::Exists < Puppet::Confine
+      def pass?(value)
+        true
+      end
+    end
+  else
+    class Provider::Confine::Exists < Puppet::Provider::Confine
+      def pass?(value)
+        true
+      end
+    end
+  end
 end
 
 class Pathname


### PR DESCRIPTION
To prevent potentially valid providers from being rejected because the specified binaries don't exist. For example, when running with a fact set for Ubuntu on OSX, don't reject the Apt package provider due to the absence of `apt-get` and friends.

Fixes #554