### PR TITLE
Ensure that environmentpath setting is set

### DIFF
--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -50,6 +50,11 @@ module RSpec::Puppet
 
         if Puppet.settings.respond_to?(:initialize_app_defaults)
           Puppet.settings.initialize_app_defaults(settings_hash)
+
+          # Forcefully apply the environmentpath setting instead of relying on
+          # the application defaults as Puppet::Test::TestHelper automatically
+          # sets this value as well, overriding our application default
+          Puppet.settings[:environmentpath] = settings_hash[:environmentpath] if settings_hash.key?(:environmentpath)
         else
           # Set settings the old way for Puppet 2.x, because that's how
           # they're defaulted in that version of Puppet::Test::TestHelper and

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -146,6 +146,12 @@ describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 d
     expect(Puppet[:strict_variables]).to eq(true)
   end
 
+  it 'overrides the environmentpath set by Puppet::Test::TestHelper' do
+    allow(test_context).to receive(:environmentpath).and_return('/path/to/my/environments')
+    subject.setup_puppet(test_context)
+    expect(Puppet[:environmentpath]).to match(%r{(C:)?/path/to/my/environments})
+  end
+
   describe '#manifest' do
     it 'returns the configured environment manifest when set' do
       allow(RSpec.configuration).to receive(:manifest).and_return("/path/to/manifest")


### PR DESCRIPTION
`Puppet::Test::TestHelper` uses `Puppet::Settings#[]=` to set `environmentpath` to a temporary directory, which always overrides anything rspec-puppet sets for the `environmentpath` as rspec-puppet sets all its settings as application defaults, which the above method overrides.

This is the only setting where rspec-puppet conflicts with `Puppet::Test::TestHelper`, so we'll set `environmentpath` with `Puppet::Settings#[]=` as well, so that our user supplied setting actually takes effect.

Fixes #556