### PR TITLE
Fix adapters compatibility for older Puppet 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A hash of default trusted facts that should be used for all the tests
 #### trusted\_node\_data
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `false` | 3.x, 4.x, 5.x
+Boolean | `false` | >=3.4, 4.x, 5.x
 
 Configures rspec-puppet to use the `$trusted` hash when compiling the
 catalogues.
@@ -143,14 +143,14 @@ The search path for environment directories.
 #### parser
 Type   | Default     | Puppet Version(s)
 ------ | ----------- | -----------------
-String | `"current"` | 3.x
+String | `"current"` | >= 3.2
 
 This switches between the 3.x (`current`) and 4.x (`future`) parsers.
 
 #### ordering
 Type   | Default        | Puppet Version(s)
 ------ | -------------- | -----------------
-String | `"title-hash"` | 3.x, 4.x, 5.x
+String | `"title-hash"` | >= 3.3, 4.x, 5.x
 
 How unrelated resources should be ordered when applying a catalogue.
  * `manifest` - Use the order in which the resources are declared in the
@@ -162,7 +162,7 @@ How unrelated resources should be ordered when applying a catalogue.
 #### strict\_variables
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `false` | 3.x, 4.x, 5.x
+Boolean | `false` | >= 3.5, 4.x, 5.x
 
 Makes Puppet raise an error when it tries to reference a variable that hasn't
 been defined (not including variables that have been explicitly set to
@@ -171,7 +171,7 @@ been defined (not including variables that have been explicitly set to
 #### stringify\_facts
 Type    | Default | Puppet Version(s)
 ------- | ------- | -----------------
-Boolean | `true`  | 3.x, 4.x, 5.x
+Boolean | `true`  | >= 3.3, 4.x, 5.x
 
 Makes rspec-puppet coerce all the fact values into strings (matching the
 behaviour of older versions of Puppet).

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -183,17 +183,45 @@ module RSpec::Puppet
       end
     end
 
-    class Adapter3X < Base
+    class Adapter30 < Base
       def settings_map
         super.concat([
           [:manifestdir, :manifest_dir],
           [:manifest, :manifest],
           [:templatedir, :template_dir],
           [:hiera_config, :hiera_config],
+        ])
+      end
+    end
+
+    class Adapter32 < Adapter30
+      def settings_map
+        super.concat([
           [:parser, :parser],
-          [:trusted_node_data, :trusted_node_data],
+        ])
+      end
+    end
+
+    class Adapter33 < Adapter32
+      def settings_map
+        super.concat([
           [:ordering, :ordering],
           [:stringify_facts, :stringify_facts],
+        ])
+      end
+    end
+
+    class Adapter34 < Adapter33
+      def settings_map
+        super.concat([
+          [:trusted_node_data, :trusted_node_data],
+        ])
+      end
+    end
+
+    class Adapter35 < Adapter34
+      def settings_map
+        super.concat([
           [:strict_variables, :strict_variables],
         ])
       end
@@ -212,7 +240,11 @@ module RSpec::Puppet
     def self.get
       [
         ['4.0', Adapter4X],
-        ['3.0', Adapter3X],
+        ['3.5', Adapter35],
+        ['3.4', Adapter34],
+        ['3.3', Adapter33],
+        ['3.2', Adapter32],
+        ['3.0', Adapter30],
         ['2.7', Adapter27]
       ].each do |(version, klass)|
         if Puppet::Util::Package.versioncmp(Puppet.version, version) >= 0

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -64,7 +64,7 @@ describe RSpec::Puppet::Adapters::Base do
   end
 end
 
-describe RSpec::Puppet::Adapters::Adapter3X, :if => (3.0 ... 4.0).include?(Puppet.version.to_f) do
+describe RSpec::Puppet::Adapters::Adapter35, :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
 
   let(:test_context) { double :environment => 'rp_env' }
 
@@ -81,11 +81,18 @@ describe RSpec::Puppet::Adapters::Adapter3X, :if => (3.0 ... 4.0).include?(Puppe
     end
   end
 
-  context 'when running on puppet 3.x, with x >= 5', :if => (3.5 ... 4.0).include?(Puppet.version.to_f) do
+end
+
+describe RSpec::Puppet::Adapters::Adapter34, :if => (3.4 ... 4.0).include?(Puppet.version.to_f) do
+
+  let(:test_context) { double :environment => 'rp_env' }
+
+  context 'when running on puppet 3.4 or later', :if => (3.4 ... 4.0).include?(Puppet.version.to_f) do
     it 'sets Puppet[:trusted_node_data] to false by default' do
       subject.setup_puppet(test_context)
       expect(Puppet[:trusted_node_data]).to eq(false)
     end
+
     it 'reads the :trusted_node_data setting' do
       allow(test_context).to receive(:trusted_node_data).and_return(true)
       subject.setup_puppet(test_context)
@@ -93,18 +100,11 @@ describe RSpec::Puppet::Adapters::Adapter3X, :if => (3.0 ... 4.0).include?(Puppe
     end
   end
 
-  context 'when running on puppet ~> 3.2', :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
-    it 'sets Puppet[:parser] to "current" by default' do
-      subject.setup_puppet(test_context)
-      expect(Puppet[:parser]).to eq("current")
-    end
+end
 
-    it 'reads the :parser setting' do
-      allow(test_context).to receive(:parser).and_return("future")
-      subject.setup_puppet(test_context)
-      expect(Puppet[:parser]).to eq("future")
-    end
-  end
+describe RSpec::Puppet::Adapters::Adapter33, :if => (3.3 ... 4.0).include?(Puppet.version.to_f) do
+
+  let(:test_context) { double :environment => 'rp_env' }
 
   context 'when running on puppet ~> 3.3', :if => (3.3 ... 4.0).include?(Puppet.version.to_f) do
     it 'sets Puppet[:stringify_facts] to true by default' do
@@ -129,6 +129,26 @@ describe RSpec::Puppet::Adapters::Adapter3X, :if => (3.0 ... 4.0).include?(Puppe
       expect(Puppet[:ordering]).to eq('manifest')
     end
   end
+
+end
+
+describe RSpec::Puppet::Adapters::Adapter32, :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
+
+  let(:test_context) { double :environment => 'rp_env' }
+
+  context 'when running on puppet ~> 3.2', :if => (3.2 ... 4.0).include?(Puppet.version.to_f) do
+    it 'sets Puppet[:parser] to "current" by default' do
+      subject.setup_puppet(test_context)
+      expect(Puppet[:parser]).to eq("current")
+    end
+
+    it 'reads the :parser setting' do
+      allow(test_context).to receive(:parser).and_return("future")
+      subject.setup_puppet(test_context)
+      expect(Puppet[:parser]).to eq("future")
+    end
+  end
+
 end
 
 describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 do


### PR DESCRIPTION
Several of the configuration parameters listed in the Adapter3X class
were not compatible with older versions of Puppet 3.x.  For puppet
modules trying to maintain compatibility with older installations, this
caused rspec to fail.  This change splits the Adapter3X class into
multiple classes for different versions, each building on the previous
to add the configuration parameters introduced in each version.