### PR TITLE
Update documentation to use Strings as Hash keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ We can write the following testcase (in `spec/defines/sysctl_spec.rb`)
 ```ruby
 describe 'sysctl' do
   let(:title) { 'baz' }
-  let(:params) { { :value => 'foo' } }
+  let(:params) { { 'value' => 'foo' } }
 
   it { is_expected.to contain_exec('sysctl/reload').with_command("/sbin/sysctl -p /etc/sysctl.conf") }
 end
@@ -557,21 +557,21 @@ Parameters of a defined type, class or application can be passed defining `:para
 and passing it a hash as seen below.
 
 ```ruby
-let(:params) { {:ensure => 'present', ...} }
+let(:params) { {'ensure' => 'present', ...} }
 ```
 
 For passing Puppet's `undef` as a paremeter value, you can simply use `:undef` and it will
 be translated to `undef` when compiling. For example:
 
 ```ruby
-let(:params) { {:user => :undef, ...} }
+let(:params) { {'user' => :undef, ...} }
 ```
 
 For references to nodes or resources as seen when using `require` or `before` properties,
 or an `application` resource you can pass the string as an argument to the `ref` helper:
 
 ```ruby
-let(:params) { :require => ref('Package', 'sudoku') }
+let(:params) { 'require' => ref('Package', 'sudoku') }
 ```
 
 Which translates to:
@@ -583,7 +583,7 @@ mydefine { 'mytitle': require => Package['sudoku'] }
 Another example, for an application setup (when using `app_management`):
 
 ```ruby
-let(:params) { { :nodes => { ref('Node', 'dbnode') => ref('Myapp::Mycomponent', 'myapp') } } }
+let(:params) { { 'nodes' => { ref('Node', 'dbnode') => ref('Myapp::Mycomponent', 'myapp') } } }
 ```
 
 Will translate to:
@@ -616,7 +616,7 @@ By default, the test environment contains no facts for your manifest to use.
 You can set them with a hash
 
 ```ruby
-let(:facts) { {:operatingsystem => 'Debian', :kernel => 'Linux', ...} }
+let(:facts) { {'operatingsystem' => 'Debian', 'kernel' => 'Linux', ...} }
 ```
 
 Facts may be expressed as a value (shown in the previous example) or a structure.  Fact keys
@@ -624,7 +624,7 @@ may be expressed as either symbols or strings.  A key will be converted to a low
 string to align with the Facter standard
 
 ```ruby
-let(:facts) { {:os => { :family => 'RedHat', :release => { :major => '7', :minor => '1', :full => '7.1.1503' } } } }
+let(:facts) { {'os' => { 'family' => 'RedHat', 'release' => { 'major' => '7', 'minor' => '1', 'full' => '7.1.1503' } } } }
 ```
 
 You can also create a set of default facts provided to all specs in your spec_helper:
@@ -632,7 +632,7 @@ You can also create a set of default facts provided to all specs in your spec_he
 ``` ruby
 RSpec.configure do |c|
   c.default_facts = {
-    :operatingsystem => 'Ubuntu'
+    'operatingsystem' => 'Ubuntu'
   }
 end
 ```
@@ -646,7 +646,7 @@ You can create top-scope variables much in the same way as an ENC.
 
 
 ```ruby
-let(:node_params) { { :hostgroup => 'webservers', :rack => 'KK04', :status => 'maintenance' } }
+let(:node_params) { { 'hostgroup' => 'webservers', 'rack' => 'KK04', 'status' => 'maintenance' } }
 ```
 
 You can also create a set of default top-scope variables provided to all specs in your spec_helper:
@@ -654,9 +654,9 @@ You can also create a set of default top-scope variables provided to all specs i
 ``` ruby
 RSpec.configure do |c|
   c.default_node_params = {
-    :owner => 'itprod',
-    :site => 'ams4',
-    :status => 'live'
+    'owner'  => 'itprod',
+    'site'   => 'ams4',
+    'status' => 'live'
   }
 end
 ```
@@ -773,7 +773,7 @@ describe 'orch_app' do
   let(:title) { 'my_awesome_app' }
   let(:params) do
     {
-      :nodes => {
+      'nodes' => {
         ref('Node', node) => ref('Orch_app::Db', title),
       }
     }
@@ -965,7 +965,7 @@ user:
 
 ```ruby
   ntpserver = hiera.lookup('ntpserver', nil, nil)
-  let(:params) { :ntpserver => ntpserver }
+  let(:params) { 'ntpserver' => ntpserver }
 ```
 
 ### Enabling hiera lookups

--- a/docs/_includes/catalogue_matchers.md
+++ b/docs/_includes/catalogue_matchers.md
@@ -26,13 +26,13 @@ matcher.
 {% highlight ruby %}
 describe 'my::type' do
   context 'with ensure => present' do
-    let(:params) { {:ensure => 'present'} }
+    let(:params) { {'ensure' => 'present'} }
 
     it { is_expected.to compile }
   end
 
   context 'with ensure => whoopsiedoo' do
-    let(:params) { {:ensure => 'whoopsiedoo'} }
+    let(:params) { {'ensure' => 'whoopsiedoo'} }
 
     it { is_expected.to compile.and_raise_error(/the expected error message/) }
   end

--- a/docs/_includes/common_inputs.md
+++ b/docs/_includes/common_inputs.md
@@ -13,7 +13,7 @@ Node parameters (or top-scope variables) such as would be provided by an ENC
 can be specified as a hash of values using `let(:node_params)`.
 
 {% highlight ruby %}
-let(:node_params) { {:hostgroup => 'web', :rack => 'KK04' } }
+let(:node_params) { {'hostgroup' => 'web', 'rack' => 'KK04' } }
 {% endhighlight %}
 
 These node parameters will be merged into the default node parameters (if set),

--- a/docs/_includes/facts_inputs.md
+++ b/docs/_includes/facts_inputs.md
@@ -5,7 +5,7 @@ By default, the test environment contains only the `hostname`, `domain`, and
 specified as a hash of values using `let(:facts)`.
 
 {% highlight ruby %}
-let(:facts) { {:operatingsystem => 'Debian', :ipaddress => '192.168.0.1'} }
+let(:facts) { {'operatingsystem' => 'Debian', 'ipaddress' => '192.168.0.1'} }
 {% endhighlight %}
 
 Facts may be expressed as a value (shown in the previous example) or
@@ -15,12 +15,12 @@ converted to a lower case string to align with the Facter standard.
 {% highlight ruby %}
 let(:facts) do
   {
-    :os => {
-      :family  => 'RedHat',
-      :release => {
-        :major => '7',
-        :minor => '1',
-        :full  => '7.1.1503',
+    'os' => {
+      'family'  => 'RedHat',
+      'release' => {
+        'major' => '7',
+        'minor' => '1',
+        'full'  => '7.1.1503',
       }
     }
   }

--- a/docs/_includes/non_host_inputs.md
+++ b/docs/_includes/non_host_inputs.md
@@ -4,14 +4,14 @@ If the object being tested takes parameters, these can be specified as a hash
 of values using `let(:params)`.
 
 {% highlight ruby %}
-let(:params) { {:ensure => 'present', :enable => true} }
+let(:params) { {'ensure' => 'present', 'enable' => true} }
 {% endhighlight %}
 
 When passing `undef` as a parameter value, it should be passed as the symbol
 `:undef`.
 
 {% highlight ruby %}
-let(:params) { {:user => :undef} }
+let(:params) { {'user' => :undef} }
 {% endhighlight %}
 
 When passing a reference to a resource (e.g. `Package['apache2']`), it should
@@ -19,7 +19,7 @@ be passed as a call to the `ref` helper (`ref(<resource type>, <resource
 title>)`)
 
 {% highlight ruby %}
-let(:params) { {:require => ref('Package', 'apache2')} }
+let(:params) { {'require' => ref('Package', 'apache2')} }
 {% endhighlight %}
 
 ### Specifying the FQDN of the test node

--- a/docs/documentation/applications/index.md
+++ b/docs/documentation/applications/index.md
@@ -23,7 +23,7 @@ describe '<application name>' do
   let(:title) { '<application instance title>' }
   let(:params) do
     {
-      :nodes => {
+      'nodes' => {
         ref('Node', node) => ref('<capitalised application name>', title),
       }
       # any additional app parameters

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -157,7 +157,7 @@ should exist in the file.
 
 {% highlight ruby %}
   context 'with compress => true' do
-    let(:params) { {:compress => true} }
+    let(:params) { {'compress' => true} }
 
     it do
       is_expected.to contain_file('/etc/logrotate.d/nginx') \
@@ -166,7 +166,7 @@ should exist in the file.
   end
 
   context 'with compress => false' do
-    let(:params) { {:compress => false} }
+    let(:params) { {'compress' => false} }
 
     it do
       is_expected.to contain_file('/etc/logrotate.d/nginx') \
@@ -188,7 +188,7 @@ it.
 
 {% highlight ruby %}
   context 'with compress => foo' do
-    let(:params) { {:compress => 'foo'} }
+    let(:params) { {'compress' => 'foo'} }
 
     it { is_expected.to compile.and_raise_error(/compress must be true or false/) }
   end
@@ -214,7 +214,7 @@ describe 'logrotate::rule' do
   end
 
   context 'with compress => true' do
-    let(:params) { {:compress => true} }
+    let(:params) { {'compress' => true} }
 
     it do
       is_expected.to contain_file('/etc/logrotate.d/nginx') \
@@ -223,7 +223,7 @@ describe 'logrotate::rule' do
   end
 
   context 'with compress => false' do
-    let(:params) { {:compress => false} }
+    let(:params) { {'compress' => false} }
 
     it do
       is_expected.to contain_file('/etc/logrotate.d/nginx') \
@@ -232,7 +232,7 @@ describe 'logrotate::rule' do
   end
 
   context 'with compress => foo' do
-    let(:params) { {:compress => 'foo'} }
+    let(:params) { {'compress' => 'foo'} }
 
     it do
       expect {


### PR DESCRIPTION
Rubocop complains about the use of the hashrocket syntax when using Symbol
keys, but because we need to maintain Ruby 1.8.7 support I can't change the
documentation to use the 1.9 syntax.

Instead, I'll just change the documentation to use String keys, which is still
syntactically correct but avoids the Rubocop warnings for users who use the
examples verbatim in their tests.