### PR TITLE
Contain Puppet monkey patches to rspec-puppet examples

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -18,6 +18,22 @@ RSpec.configure do |c|
   c.add_setting :enable_pathname_stubbing, :default => false
 end
 
+module RSpec::Puppet
+  def self.rspec_puppet_example?
+    return false if state_obj.current_example.nil?
+
+    state_obj.current_example.example_group.included_modules.include?(RSpec::Puppet::Support)
+  end
+
+  def self.state_obj
+    @state_obj ||= if RSpec.respond_to?(:current_example)
+                     RSpec
+                   else
+                     RSpec::Puppet::EventListener
+                   end
+  end
+end
+
 require 'rspec-puppet/monkey_patches'
 
 RSpec.configure do |c|

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -21,17 +21,7 @@ end
 
 module RSpec::Puppet
   def self.rspec_puppet_example?
-    return false if state_obj.current_example.nil?
-
-    state_obj.current_example.example_group.included_modules.include?(RSpec::Puppet::Support)
-  end
-
-  def self.state_obj
-    @state_obj ||= if RSpec.respond_to?(:current_example)
-                     RSpec
-                   else
-                     RSpec::Puppet::EventListener
-                   end
+    RSpec::Puppet::EventListener.rspec_puppet_example?
   end
 end
 

--- a/lib/rspec-puppet/consts.rb
+++ b/lib/rspec-puppet/consts.rb
@@ -1,0 +1,31 @@
+module RSpec::Puppet::Consts
+  STUBBED_CONSTS = {
+    :posix => {
+      'File::PATH_SEPARATOR' => ':',
+      'File::ALT_SEPARATOR' => nil,
+      'Pathname::SEPARATOR_PAT' => /#{Regexp.quote('/')}/,
+    },
+    :windows => {
+      'File::PATH_SEPARATOR' => ';',
+      'File::ALT_SEPARATOR' => "\\",
+      'Pathname::SEPARATOR_PAT' => /[#{Regexp.quote("\\")}#{Regexp.quote('/')}]/,
+    }
+  }
+
+  def self.stub_consts_for(platform)
+    STUBBED_CONSTS[platform].each do |const_name, const_value|
+      stub_const_wrapper(const_name, const_value)
+    end
+  end
+
+  def self.stub_const_wrapper(const, value)
+    klass_name, const_name = const.split('::', 2)
+    klass = Object.const_get(klass_name)
+    klass.send(:remove_const, const_name) if klass.const_defined?(const_name)
+    klass.const_set(const_name, value)
+  end
+
+  def self.restore_consts
+    stub_consts_for(RSpec.configuration.platform)
+  end
+end

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -2,17 +2,27 @@ require 'pathname'
 
 class RSpec::Puppet::EventListener
   def self.example_started(example)
-    @current_example = example
+    if rspec3?
+      @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
+    else
+      @rspec_puppet_example = example.example_group.ancestors.include?(RSpec::Puppet::Support)
+    end
   end
 
-  def self.current_example
-    @current_example
+  def self.rspec_puppet_example?
+    @rspec_puppet_example || false
+  end
+
+  def self.rspec3?
+    if @rspec3.nil?
+      @rspec3 = defined?(RSpec::Core::Notifications)
+    end
+
+    @rspec3
   end
 end
 
-unless RSpec.respond_to?(:current_example)
-  RSpec.configuration.reporter.register_listener(RSpec::Puppet::EventListener, :example_started)
-end
+RSpec.configuration.reporter.register_listener(RSpec::Puppet::EventListener, :example_started)
 
 module Puppet
   # Allow rspec-puppet to prevent Puppet::Type from automatically picking

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -78,7 +78,7 @@ module Puppet
       if RSpec::Puppet.rspec_puppet_example?
         pretending = Puppet::Util::Platform.pretend_platform
 
-        if pretending
+        unless pretending.nil?
           Puppet::Util::Platform.pretend_to_be nil
           RSpec::Puppet::Consts.stub_consts_for(RSpec.configuration.platform)
         end
@@ -86,7 +86,7 @@ module Puppet
         environment.send(:value_cache).clear if environment.respond_to?(:value_cache, true)
         output = old_find_manifests_in_modules(pattern, environment)
 
-        if pretending
+        unless pretending.nil?
           Puppet::Util::Platform.pretend_to_be pretending
           RSpec::Puppet::Consts.stub_consts_for pretending
         end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -53,12 +53,15 @@ module RSpec::Puppet
       end
 
       munged_facts = facts_hash(nodename(type))
-      return unless munged_facts.key?('operatingsystem')
 
-      if munged_facts['operatingsystem'].to_s.downcase == 'windows'
-        RSpec::Puppet::Consts.stub_consts_for(:windows)
-      else
-        RSpec::Puppet::Consts.stub_consts_for(:posix)
+      ['operatingsystem', 'osfamily'].each do |os_fact|
+        if munged_facts.key?(os_fact)
+          if munged_facts[os_fact].to_s.downcase == 'windows'
+            RSpec::Puppet::Consts.stub_consts_for(:windows)
+          else
+            RSpec::Puppet::Consts.stub_consts_for(:posix)
+          end
+        end
       end
     end
 
@@ -358,11 +361,13 @@ module RSpec::Puppet
 
     def build_catalog(*args)
       build_facts = args[1]
-      if build_facts.key?('operatingsystem')
-        if build_facts['operatingsystem'].to_s.downcase == 'windows'
-          Puppet::Util::Platform.pretend_to_be :windows
-        else
-          Puppet::Util::Platform.pretend_to_be :posix
+      ['operatingsystem', 'osfamily'].each do |os_fact|
+        if build_facts.key?(os_fact)
+          if build_facts[os_fact].to_s.downcase == 'windows'
+            Puppet::Util::Platform.pretend_to_be :windows
+          else
+            Puppet::Util::Platform.pretend_to_be :posix
+          end
         end
       end
 

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -54,8 +54,9 @@ module RSpec::Puppet
       end
 
       munged_facts = facts_hash(nodename(type))
+      return unless munged_facts.key?('operatingsystem')
 
-      if munged_facts['operatingsystem'] && munged_facts['operatingsystem'].to_s.downcase == 'windows'
+      if munged_facts['operatingsystem'].to_s.downcase == 'windows'
         stub_const_wrapper('File::PATH_SEPARATOR', ';')
         stub_const_wrapper('File::ALT_SEPARATOR', "\\")
         stub_const_wrapper('Pathname::SEPARATOR_PAT', /[#{Regexp.quote(File::ALT_SEPARATOR)}#{Regexp.quote(File::SEPARATOR)}]/)

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -352,18 +352,20 @@ module RSpec::Puppet
     end
 
     def stub_facts!(facts)
-      if facts['operatingsystem']
-        if facts['operatingsystem'].to_s.downcase == 'windows'
-          Puppet::Util::Platform.pretend_to_be :windows
-        else
-          Puppet::Util::Platform.pretend_to_be :posix
-        end
-      end
       Puppet.settings[:autosign] = false
       facts.each { |k, v| Facter.add(k) { setcode { v } } }
     end
 
     def build_catalog(*args)
+      build_facts = args[1]
+      if build_facts.key?('operatingsystem')
+        if build_facts['operatingsystem'].to_s.downcase == 'windows'
+          Puppet::Util::Platform.pretend_to_be :windows
+        else
+          Puppet::Util::Platform.pretend_to_be :posix
+        end
+      end
+
       @@cache.get(*args) do |*args|
         build_catalog_without_cache(*args)
       end

--- a/spec/classes/test_duplicate_alias_spec.rb
+++ b/spec/classes/test_duplicate_alias_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'test::duplicate_alias' do
+  let(:facts) { { 'operatingsystem' => 'Debian' } }
   it { should compile }
   it { should contain_exec('foo_bar_1') }
   it { should contain_exec('foo_bar_2') }

--- a/spec/hosts/good_dep_host_spec.rb
+++ b/spec/hosts/good_dep_host_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe 'good_dep_host' do
+  let(:facts) { { 'operatingsystem' => 'Debian' } }
+
   it { should compile.with_all_deps }
 end

--- a/spec/unit/matchers/compile_spec.rb
+++ b/spec/unit/matchers/compile_spec.rb
@@ -9,6 +9,7 @@ if Puppet.version.to_f >= 3.0
     subject { RSpec::Puppet::ManifestMatchers::Compile.new }
 
     let(:catalogue) { lambda { load_catalogue(:host) } }
+    let(:facts) { { 'operatingsystem' => 'Debian' } }
 
     describe "a valid manifest" do
       let (:pre_condition) { 'file { "/tmp/resource": }' }


### PR DESCRIPTION
Changes all the monkey patches so that they'll call the original implementation when used outside of an rspec-puppet example. This is so that we don't modify the behaviour of any Ruby unit tests that might run inside the same rspec process.

The constants also are only stubbed if an operatingsystem fact has been specified in the example, rather than defaulting to POSIX unless otherwise specified.

Fixes #577 