### PR TITLE
Convert trusted_facts hash keys from symbols to strings

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -257,10 +257,10 @@ module RSpec::Puppet
       extensions = {}
 
       if RSpec.configuration.default_trusted_facts.any?
-        extensions.merge!(RSpec.configuration.default_trusted_facts)
+        extensions.merge!(munge_facts(RSpec.configuration.default_trusted_facts))
       end
 
-      extensions.merge!(trusted_facts) if self.respond_to?(:trusted_facts)
+      extensions.merge!(munge_facts(trusted_facts)) if self.respond_to?(:trusted_facts)
       extensions
     end
 

--- a/spec/classes/trusted_facts_spec.rb
+++ b/spec/classes/trusted_facts_spec.rb
@@ -36,7 +36,7 @@ describe 'trusted_facts', :if => Puppet::Util::Package.versioncmp(Puppet.version
 
   context 'with extensions' do
     extensions = {
-      'pp_uuid'                 => 'ED803750-E3C7-44F5-BB08-41A04433FE2E',
+      :pp_uuid                  => 'ED803750-E3C7-44F5-BB08-41A04433FE2E',
       '1.3.6.1.4.1.34380.1.2.1' => 'ssl-termination'
     }
     let(:trusted_facts) { extensions }


### PR DESCRIPTION
So that the behaviour is consistent with the facts hash.

Fixes #572 