### PR TITLE
Allow nodename derived fact overrides to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ Boolean | `true`  | 2.x, 3.x, 4.x, 5.x
 Configures rspec-puppet to automatically create a link from the root of your
 module to `spec/fixtures/<module name>` at the beginning of the test run.
 
+#### derive\_node\_facts\_from\_nodename
+Type    | Default | Puppet Version(s)
+------- | ------- | -----------------
+Boolean | `true`  | 2.x, 3.x, 4.x, 5.x
+
+If `true`, rspec-puppet will override the `fdqn`, `hostname`, and `domain`
+facts with values that it derives from the node name (specified with
+`let(:node)`.
+
+In some circumstances (e.g. where your nodename/certname is not the same as
+your FQDN), this behaviour is undesirable and can be disabled by changing this
+setting to `false`.
+
 ## Naming conventions
 
 For clarity and consistency, I recommend that you use the following directory

--- a/docs/documentation/configuration/index.md
+++ b/docs/documentation/configuration/index.md
@@ -190,3 +190,16 @@ Configures rspec-puppet to stub out `Pathname#absolute?` with its own
 implementation. This should only be enabled if you're running into an issue
 running cross-platform tests where you have Ruby code (types, providers,
 functions, etc) that use `Pathname#absolute?`.
+
+### derive\_node\_facts\_from\_nodename
+**Type:** Boolean<br />
+**Default:** `true`<br />
+**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+
+If `true`, rspec-puppet will override the `fdqn`, `hostname`, and `domain`
+facts with values that it derives from the node name (specified with
+`let(:node)`.
+
+In some circumstances (e.g. where your nodename/certname is not the same as
+your FQDN), this behaviour is undesirable and can be disabled by changing this
+setting to `false`.

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -44,8 +44,9 @@ RSpec.configure do |c|
   c.add_setting :ordering, :default => 'title-hash'
   c.add_setting :stringify_facts, :default => true
   c.add_setting :strict_variables, :default => false
-  c.add_setting :adapter
   c.add_setting :setup_fixtures, :default => true
+  c.add_setting :derive_node_facts_from_nodename, :default => true
+  c.add_setting :adapter
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
 
   c.before(:all) do

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -227,7 +227,7 @@ module RSpec::Puppet
 
       # Merge node facts again on top of `let(:facts)` facts, but only if
       # a node name is given with `let(:node)`
-      if respond_to?(:node)
+      if respond_to?(:node) && RSpec.configuration.derive_node_facts_from_nodename
         result_facts.merge!(munge_facts(node_facts))
         (result_facts['networking'] ||= {}).merge!(networking_facts)
       end

--- a/spec/classes/test_basic_spec.rb
+++ b/spec/classes/test_basic_spec.rb
@@ -24,5 +24,22 @@ describe 'test::basic' do
       it { should contain_notify('eth0') }
       it { should contain_notify('test123') }
     end
+
+    context 'when derive_node_facts_from_nodename => false' do
+      let(:pre_condition) { 'notify { $::fqdn: }' }
+      let(:node) { 'mycertname.test.com' }
+      let(:facts) do
+        {
+          :fqdn => 'myhostname.test.com',
+        }
+      end
+
+      before do
+        RSpec.configuration.derive_node_facts_from_nodename = false
+      end
+
+      it { should contain_notify('myhostname.test.com') }
+      it { should_not contain_notify('mycertname.test.com') }
+    end
   end
 end


### PR DESCRIPTION
Allows the user to disable nodename derived facts overriding the specified facts (basically restoring the 2.5.x behaviour). This is a bandaid fix until 3.x when I can introduce separate `certname` and `fqdn` inputs.

/cc @seanmil 

Fixes #565 
Replaces #566 