### PR TITLE
(maint) extend monkey patches for more platform independence

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -110,6 +110,21 @@ module Puppet
   end
 
   module Util
+    if respond_to?(:get_env)
+      alias :old_get_env :get_env
+      module_function :old_get_env
+
+      def get_env(name, mode = default_env)
+        if RSpec::Puppet.rspec_puppet_example?
+          # use the actual platform, not the pretended
+         old_get_env(name, Platform.actual_platform)
+        else
+         old_get_env(name, mode)
+        end
+      end
+      module_function :get_env
+    end
+
     # Allow rspec-puppet to pretend to be different platforms.
     module Platform
       alias :old_windows? :windows?


### PR DESCRIPTION
During setup_puppet, running on linux, pretending to be windows, Puppet::Util.get_env()
gets called, and fails:

```
NameError:
  uninitialized constant Puppet::Util::Windows
# /home/david/gems/ruby/2.3.0/gems/puppet-5.0.1/lib/puppet/util.rb:43:in `get_env'
# /home/david/gems/ruby/2.3.0/gems/puppet-5.0.1/lib/puppet/node/environment.rb:493:in `extralibs'
# /home/david/gems/ruby/2.3.0/gems/puppet-5.0.1/lib/puppet/node/environment.rb:50:in `create'
# /home/david/git/rspec-puppet/lib/rspec-puppet/adapters.rb:135:in `setup_puppet'
# /home/david/git/rspec-puppet/lib/rspec-puppet.rb:99:in `block (2 levels) in <top (required)>'
```

This is easily reproducable using rspec-puppet 2.6.5 and commit 181bdf45eef34cbbe44d0d0443ee6f6860548c13 from puppetlabs-sqlserver with `bundle exec rspec -fd spec/defines/user/permissions_spec.rb:133 spec/defines/user/permissions_spec.rb:145`

To fix, this commit also patches the get_env function to use the actual platform,
instead of the pretended platform to make environment lookups.