### PR TITLE
Add note to create metadata.json to module before running init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 ## Starting out with a new module
 
-When you start out on a new module, run `rspec-puppet-init` to create the necessary files to configure rspec-puppet for your module's tests.
+When you start out on a new module, create a metadata.json file for your module and then run `rspec-puppet-init` to create the necessary files to configure rspec-puppet for your module's tests.
+
 
 ## Configure manifests for Puppet 4
 


### PR DESCRIPTION
"Resolves" #592 As the implementation is arguably correct this just adds a note to the README for new users.

Should also be updated on the http://rspec-puppet.com/ home page and tutorials