### PR TITLE
(#595) Clear environment cache only if pretending to be a platform

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -105,7 +105,9 @@ module Puppet
           RSpec::Puppet::Consts.stub_consts_for(RSpec.configuration.platform)
         end
 
-        environment.send(:value_cache).clear if environment.respond_to?(:value_cache, true)
+        if pretending && pretending != Puppet::Util::Platform.actual_platform
+          environment.send(:value_cache).clear if environment.respond_to?(:value_cache, true)
+        end
         output = old_find_manifests_in_modules(pattern, environment)
 
         unless pretending.nil?


### PR DESCRIPTION
Clearing this cache causes a significant performance degradation on Puppet < 4.0.0, so only do it when absolutely necessary.

Fixes #595