### PR TITLE
Friendlier message when rspec-puppet-init thinks it is running from a control repo

### DIFF
--- a/docs/documentation/setup/index.md
+++ b/docs/documentation/setup/index.md
@@ -54,6 +54,7 @@ require.
 
 {% highlight console %}
 $ cd path/to/your/module
+$ touch metadata.json
 $ rspec-puppet-init
 {% endhighlight %}
 

--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -12,6 +12,14 @@ module RSpec::Puppet
         return false
       end
 
+      if control_repo?
+        $stderr.puts <<-END
+Unable to find a metadata.json file. If this is a module, please create a
+metadata.json file and try again.
+END
+        return false
+      end
+
       safe_setup_directories(module_name)
       safe_touch(File.join('spec', 'fixtures', 'manifests', 'site.pp'))
 


### PR DESCRIPTION
Fixes #592 #594