### PR TITLE
(HI-581) load hiera windows support before monkey patching ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
 bundler_args: --without development
+# workaround bundler/rubygems version mismatch on new trusty images for ruby 1.9
+before_install: gem install bundler -v '1.15.4'
 
 rvm:
   - 2.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,5 +46,6 @@ test_script:
   - bundle exec rake test
 
 notifications:
-  email:
-    - tim@sharpe.id.au
+  - provider: Email
+    to:
+      - tim@sharpe.id.au

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -1,5 +1,12 @@
 require 'pathname'
 
+# Load this library before enabling the monkey-patches to avoid HI-581
+begin
+require 'hiera/util/win32'
+rescue LoadError
+  # ignore this on installs without hiera, e.g. puppet 3 gems
+end
+
 class RSpec::Puppet::EventListener
   def self.example_started(example)
     if rspec3?


### PR DESCRIPTION
This works:

```ruby
require 'hiera/util/win32'
it do
  is_expected.to compile
end
```

This does not:

```ruby
it do
  require 'hiera/util/win32'
  is_expected.to compile
end
```

And produces the following error:

```
Failure/Error: require 'hiera/util/win32'

LoadError:
  cannot load such file -- fiddle/import
```