### PR TITLE
(PDK-500) Set pretend_to_be after the catalog has compiled

### DIFF
--- a/spec/fixtures/modules/test/manifests/windows.pp
+++ b/spec/fixtures/modules/test/manifests/windows.pp
@@ -5,4 +5,8 @@ class test::windows {
     mode     => '0755',
     provider => windows,
   }
+
+  package { 'test':
+    ensure => 'installed',
+  }
 }


### PR DESCRIPTION
The problem this fixes is this workflow:

Running specs on posix.
Simulating compilation on a posix master.
Of an agent catalog which may be either for a posix or windows node and
therefore may include os facts used during catalog compilation to
determine paths to files.
Where the catalog also uses server side functions that ultimately make use of
Puppet::Util.absolute_path?

The case that came up was Puppet's file() function, such as
file('/some/path', '/dev/null'). In the above case, if Puppet is now
pretend_to_be windows, that function call will error out because
'/dev/null' is not absolute and is not found.

Unfortunately this patch is not sufficient for the case that I think was
originally being handled:

Running specs on windows.
Simulating compilation on a posix master.

For that case, you want to pretend_to_be posix prior to compilation to
avoid the same problem.

So I think that a more deliberate switch needs to be created for this,
something more certain than a hueristic based off the agent's os facts,
maybe testing actual_platform to determine whether or not to
pretend_to_be something before/after compilation?

There's also the apply case to consider if that needs to be called out
separately?