### PR TITLE
WIP: Adds rspec configuration to set default facterdb search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
+## Unreleased
+ * Adds rspec configuration to set default facterdb search paths
 
 ## [2.6.9]
 

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -48,6 +48,8 @@ RSpec.configure do |c|
   c.add_setting :derive_node_facts_from_nodename, :default => true
   c.add_setting :adapter
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
+  c.add_setting :facterdb_skip_defaultdb, :default => false
+  c.add_setting :facterdb_search_paths, :default => File.join('spec', 'fixtures','facts')
 
   c.before(:all) do
     if RSpec.configuration.setup_fixtures?
@@ -78,6 +80,10 @@ RSpec.configure do |c|
 
     c.before :each do
       begin
+        # this is useful when people are using puppet-debugger or rspec-puppete-facts
+        # in conjuction with their tests
+        ENV['FACTERDB_SEARCH_PATHS'] = RSpec.configuration.facterdb_search_paths
+        ENV['FACTERDB_SKIP_DEFAULTDB'] = RSpec.configuration.facterdb_skip_defaultdb
         Puppet::Test::TestHelper.before_each_test
       rescue Puppet::Context::DuplicateRollbackMarkError
         Puppet::Test::TestHelper.send(:initialize_settings_before_each)
@@ -87,6 +93,8 @@ RSpec.configure do |c|
 
     c.after :each do
       begin
+        ENV['FACTERDB_SEARCH_PATHS'] = nil
+        ENV['FACTERDB_SKIP_DEFAULTDB'] = nil
         Puppet::Test::TestHelper.after_each_test
       rescue
       end
@@ -94,6 +102,10 @@ RSpec.configure do |c|
   end
 
   c.before :each do
+    # this is useful when people are using puppet-debugger or rspec-puppete-facts
+    # in conjuction with their tests
+    ENV['FACTERDB_SEARCH_PATHS'] = RSpec.configuration.facterdb_search_paths
+    ENV['FACTERDB_SKIP_DEFAULTDB'] = RSpec.configuration.facterdb_skip_defaultdb
     if RSpec::Puppet.rspec_puppet_example?
       @adapter = RSpec::Puppet::Adapters.get
       @adapter.setup_puppet(self)
@@ -109,6 +121,8 @@ RSpec.configure do |c|
   end
 
   c.after(:each) do
+    ENV['FACTERDB_SEARCH_PATHS'] = nil
+    ENV['FACTERDB_SKIP_DEFAULTDB'] = nil
     RSpec::Puppet::Consts.restore_consts if RSpec::Puppet.rspec_puppet_example?
   end
 end

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -109,4 +109,22 @@ describe RSpec::Puppet::Support do
       end
     end
   end
+
+  describe 'facterdb variables' do
+    it 'create default values' do
+      expect(RSpec.configuration.facterdb_search_paths).to eq('spec/fixtures/facts')
+      expect(RSpec.configuration.facterdb_skip_defaultdb).to be false
+    end
+
+    it 'set variables' do
+      RSpec.configuration.facterdb_skip_defaultdb = 'yes'
+      expect(ENV['FACTERDB_SEARCH_PATHS']).to eq('spec/fixtures/facts')
+      expect(ENV['FACTERDB_SKIP_DEFAULTDB']).to eq('yes')
+    end
+
+    it 'unset variables' do
+      expect(ENV['FACTERDB_SEARCH_PATHS']).to be nil
+      expect(ENV['FACTERDB_SKIP_DEFAULTDB']).to be nil
+    end
+  end
 end


### PR DESCRIPTION
  * FacterDB 0.4.0 added a new feature that allows the user to
    supply their own custom fact sets.  While this feature alone
    has no affect on rspec-puppet.  Other bolt on tools like
    puppet-debugger and rspec-puppet-facts which rely on facterdb
    and driven by rspec-puppet. This commit allows the user
    to set some facterdb environment variables through the rspec
    configuration setting so that using this new facterdb feature
    is more seemless with rspec-puppet.

  * This adds two new configuration settings
     - facterdb_skip_defaultdb
     - facterdb_search_paths

     Both of these settings are set and unset upon each test