### PR TITLE
Adds the ability to spec test an arbitrary string

### DIFF
--- a/docs/documentation/configuration/index.md
+++ b/docs/documentation/configuration/index.md
@@ -203,3 +203,12 @@ facts with values that it derives from the node name (specified with
 In some circumstances (e.g. where your nodename/certname is not the same as
 your FQDN), this behaviour is undesirable and can be disabled by changing this
 setting to `false`.
+
+### string
+**Type:** String<br />
+**Default:** `nil`<br />
+**Puppet Version(s):** 2.x, 3.x, 4.x, 5.x
+
+Set this to an arbitrary string of Puppet code and define an example of type
+`:string`. Rather than reading files off disk, `rspec-puppet` will run the tests
+against this string of code.

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -48,6 +48,7 @@ RSpec.configure do |c|
   c.add_setting :derive_node_facts_from_nodename, :default => true
   c.add_setting :adapter
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
+  c.add_setting :string, :default => nil
 
   c.before(:all) do
     if RSpec.configuration.setup_fixtures?

--- a/lib/rspec-puppet/example.rb
+++ b/lib/rspec-puppet/example.rb
@@ -7,6 +7,7 @@ require 'rspec-puppet/example/type_example_group'
 require 'rspec-puppet/example/type_alias_example_group'
 require 'rspec-puppet/example/provider_example_group'
 require 'rspec-puppet/example/application_example_group'
+require 'rspec-puppet/example/string_example_group'
 
 RSpec::configure do |c|
 
@@ -27,6 +28,7 @@ RSpec::configure do |c|
   c.rspec_puppet_include RSpec::Puppet::TypeAliasExampleGroup, :type_alias, %w[spec type_aliases]
   c.rspec_puppet_include RSpec::Puppet::ProviderExampleGroup, :provider, %w[spec providers]
   c.rspec_puppet_include RSpec::Puppet::ApplicationExampleGroup, :application, %w[spec applications]
+  c.rspec_puppet_include RSpec::Puppet::StringExampleGroup, :string, %w[spec strings]
 
   # Hook for each example group type to remove any caches or instance variables, since they will remain
   # and cause a memory leak.  Can't be assigned per type by :file_path, so check for its presence.

--- a/lib/rspec-puppet/example/string_example_group.rb
+++ b/lib/rspec-puppet/example/string_example_group.rb
@@ -1,0 +1,18 @@
+module RSpec::Puppet
+  module StringExampleGroup
+    include RSpec::Puppet::ManifestMatchers
+    include RSpec::Puppet::Support
+
+    def catalogue
+      @catalogue ||= load_catalogue(:string)
+    end
+
+    def exported_resources
+      lambda { load_catalogue(:string, true) }
+    end
+
+    def rspec_puppet_cleanup
+      @catalogue = nil
+    end
+  end
+end

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -151,6 +151,8 @@ module RSpec::Puppet
         nil
       elsif type == :type_alias
         "$test = #{str_from_value(opts[:test_value])}\nassert_type(#{self.class.top_level_description}, $test)"
+      elsif type == :string
+        RSpec.configuration.string
       end
     end
 

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -108,5 +108,13 @@ describe RSpec::Puppet::Support do
         expect(subject.build_code(:class, {})).to eq "\ninclude class_name\npost_condition"
       end
     end
+
+    context "with code passed in as a string" do
+      it "builds a test manifest" do
+        allow(RSpec.configuration).to receive(:string).and_return("example code")
+        expect(subject.build_code(:string, {})).to eq "\nexample code"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
We are building a web service that will enable rspec-puppet testing of
POSTed Puppet code. The use case is a tutorial that will allow users to
type in a snippet of Puppet code and get immediate validation of whether
they'd completed the exercise correctly.

Example test:

```Ruby
require 'rspec-puppet'

RSpec::configure do |c|
  c.string = "package { 'httpd':
    ensure => present,
  }"
end

describe 'apache', :type => :string do
  let(:node) { 'testhost.example.com' }

  describe 'when called with no parameters on redhat' do
    let (:facts) { { ... } }

    it {
      should contain_package('httpd').with({
        'ensure' => 'present',
      })
    }
  end
end
```