### PR TITLE
(#620) Double quote titles containing single quotes

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -132,15 +132,15 @@ module RSpec::Puppet
         end
       elsif type == :application
         if opts.has_key?(:params)
-          "site { #{class_name} { '#{title}': #{param_str(opts[:params])} } }"
+          "site { #{class_name} { #{sanitise_resource_title(title)}: #{param_str(opts[:params])} } }"
         else
           raise ArgumentError, "You need to provide params for an application"
         end
       elsif type == :define
         title_str = if title.is_a?(Array)
-                      '[' + title.map { |r| "'#{r}'" }.join(', ') + ']'
+                      '[' + title.map { |r| sanitise_resource_title(r) }.join(', ') + ']'
                     else
-                      "'#{title}'"
+                      sanitise_resource_title(title)
                     end
         if opts.has_key?(:params)
           "#{class_name} { #{title_str}: #{param_str(opts[:params])} }"
@@ -152,6 +152,10 @@ module RSpec::Puppet
       elsif type == :type_alias
         "$test = #{str_from_value(opts[:test_value])}\nassert_type(#{self.class.top_level_description}, $test)"
       end
+    end
+
+    def sanitise_resource_title(title)
+      title.include?("'") ? title.inspect : "'#{title}'"
     end
 
     def nodename(type)

--- a/spec/defines/test_title_quote_spec.rb
+++ b/spec/defines/test_title_quote_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'test::notify' do
+  let(:title) { "test'" }
+
+  it { should contain_notify("test'") }
+end

--- a/spec/fixtures/modules/test/manifests/notify.pp
+++ b/spec/fixtures/modules/test/manifests/notify.pp
@@ -1,0 +1,3 @@
+define test::notify() {
+  notify { $name: }
+}


### PR DESCRIPTION
Improves the handling of resource titles that contain single quotes. Rather than wrapping all titles in single quotes, check if the title contains a single quote and instead double quote.

Fixes #620