### PR TITLE
Reset default providers for Types before compiling catalogue

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -337,6 +337,8 @@ module RSpec::Puppet
 
       stub_facts! facts_val
 
+      Puppet::Type.eachtype { |type| type.defaultprovider = nil }
+
       node_facts = Puppet::Node::Facts.new(nodename, facts_val.dup)
       node_params = facts_val.merge(node_params)
 
@@ -356,6 +358,7 @@ module RSpec::Puppet
 
     def stub_facts!(facts)
       Puppet.settings[:autosign] = false
+      Facter.clear
       facts.each { |k, v| Facter.add(k) { setcode { v } } }
     end
 

--- a/spec/classes/relationship__titles_spec.rb
+++ b/spec/classes/relationship__titles_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'relationships::titles' do
-  let(:facts) { {:operatingsystem => 'Debian', :kernel => 'Linux'} }
+  let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'debian', :kernel => 'Linux'} }
 
   it { should compile }
   it { should compile.with_all_deps }

--- a/spec/classes/test_multi_os.rb
+++ b/spec/classes/test_multi_os.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'test::multi_os' do
+  context 'on windows' do
+    let(:facts) do
+      { :operatingsystem => 'windows' }
+    end
+
+    it { should compile.with_all_deps }
+
+    it 'sets the provider of the File resource to :windows' do
+      catalogue.resource('file', 'C:/test').to_ral.provider.class.name.should eq(:windows)
+    end
+  end
+
+  context 'on Debian' do
+    let(:facts) do
+      { :operatingsystem => 'Debian' }
+    end
+
+    it { should compile.with_all_deps }
+
+    it 'sets the provider of the File resource to :posix' do
+      catalogue.resource('file', '/test').to_ral.provider.class.name.should eq(:posix)
+    end
+  end
+end

--- a/spec/fixtures/modules/test/manifests/multi_os.pp
+++ b/spec/fixtures/modules/test/manifests/multi_os.pp
@@ -1,0 +1,10 @@
+class test::multi_os {
+  $file = $::operatingsystem ? {
+    'windows' => 'C:/test',
+    default   => '/test',
+  }
+
+  file { $file:
+    ensure => file,
+  }
+}


### PR DESCRIPTION
Previously, if the catalogue had been converted into a RAL catalogue
(done when using the `compile.with_all_deps` matcher), the default
provider would be cached for the duration of the Ruby process and any
future `Puppet::Type` objects would have that provider set, even if the
Facter values had changed and the provider was no longer suitable.

This lead to unpredictable behaviour when switching between compiling
for different platforms and when parallelising the test execution.

The simple solution to this is to clear cached default provider for each
Puppet::Type before compiling the catalogue.