### PR TITLE
Stub out Puppet::Util::Windows::Security.supports_acl?

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -272,6 +272,21 @@ Puppet::Type.type(:exec).paramclass(:user).validate do |value|
   end
 end
 
+# Stub out Puppet::Util::Windows::Security.supports_acl? if it has been
+# defined. This check only makes sense when applying the catalogue to a host
+# and so can be safely stubbed out for unit testing.
+Puppet::Type.type(:file).provide(:windows).class_eval do
+  old_supports_acl = instance_method(:supports_acl?) if respond_to?(:supports_acl?)
+
+  def supports_acl?(path)
+    if RSpec::Puppet.rspec_puppet_example?
+      true
+    else
+      old_supports_acl.bind(self).call(value)
+    end
+  end
+end
+
 # Prevent Puppet from requiring 'puppet/util/windows' if we're pretending to be
 # windows, otherwise it will require other libraries that probably won't be
 # available on non-windows hosts.

--- a/spec/fixtures/modules/test/manifests/windows.pp
+++ b/spec/fixtures/modules/test/manifests/windows.pp
@@ -2,6 +2,7 @@ class test::windows {
   file { 'C:\\test.txt':
     content  => 'something',
     ensure   => file,
+    mode     => '0755',
     provider => windows,
   }
 }


### PR DESCRIPTION
When testing a Windows catalogue on a *nix host, and the catalogue
contains a File resource with a mode/owner/group parameter, *and* the
catalogue has been converted into a RAL catalogue, the `windows` File
provider will call Puppet::Util::Windows::Security.supports_acl? (which
is mixed into the provider class) when validating the parameters.

This method only makes sense when applying the catalogue to an actual
host, not when unit testing the catalogue, so it can be safely stubbed
out.