### PR TITLE
Monkey Patch windows libraries for when kernel fact is set.

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -293,7 +293,7 @@ end
 module Kernel
   alias :old_require :require
   def require(path)
-    return if path == 'puppet/util/windows' && RSpec::Puppet.rspec_puppet_example? && Puppet::Util::Platform.pretend_windows?
+    return if (['puppet/util/windows', 'win32ole'].include?(path)) && RSpec::Puppet.rspec_puppet_example? && Puppet::Util::Platform.pretend_windows?
     old_require(path)
   end
 end

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -293,7 +293,7 @@ end
 module Kernel
   alias :old_require :require
   def require(path)
-    return if (['puppet/util/windows', 'win32ole'].include?(path)) && RSpec::Puppet.rspec_puppet_example? && Puppet::Util::Platform.pretend_windows?
+    return if (['puppet/util/windows', 'win32ole', 'win32/resolv'].include?(path)) && RSpec::Puppet.rspec_puppet_example? && Puppet::Util::Platform.pretend_windows?
     old_require(path)
   end
 end


### PR DESCRIPTION
When running rspec-puppet on a non-windows node ( in my case a mac ) and set the :kernel windows fact to windows the :ipaddress fact begins to be evaluated for a windows machine ( because it's confined by this fact ) which causes some win32 libraries to get required.

Test to reproduce this
```ruby
require 'spec_helper'

describe 'role::sqlserver' do
    let(:facts) do
      {
        architecture:           'x64',
        osfamily:               'windows',
        kernel:                 'windows',
        operatingsystem:        'windows',
        operatingsystemrelease: '2016',
        staged_package:         nil,
      }
    end

    it { is_expected.to compile.with_all_deps }
end

```

Stack Trace
```
1) role::sqlserver should compile into a catalogue without dependency cycles should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile.with_all_deps }

     LoadError:
       cannot load such file -- win32ole
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/monkey_patches.rb:282:in `require'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/monkey_patches.rb:282:in `require'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/wmi.rb:18:in `connect'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/wmi.rb:31:in `execquery'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/ip/windows.rb:100:in `network_adapter_configurations'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/ip/windows.rb:140:in `get_preferred_network_adapters'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/ip/windows.rb:115:in `get_preferred_ipv4_adapters'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/ipaddress.rb:110:in `block (2 levels) in <top (required)>'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/resolution.rb:157:in `resolve_value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/core/resolvable.rb:63:in `block (2 levels) in value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/core/resolvable.rb:62:in `block in value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/core/resolvable.rb:84:in `with_timing'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/core/resolvable.rb:61:in `value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/fact.rb:161:in `block in find_first_real_value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/fact.rb:160:in `each'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/fact.rb:160:in `find_first_real_value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/fact.rb:113:in `block in value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/fact.rb:145:in `searching'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/fact.rb:110:in `value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter/util/collection.rb:130:in `value'
     # ./.bundle/ruby/2.4.0/gems/facter-2.5.1/lib/facter.rb:117:in `value'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/catalog/compiler.rb:368:in `block in set_server_facts'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/catalog/compiler.rb:367:in `each'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/catalog/compiler.rb:367:in `set_server_facts'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/catalog/compiler.rb:69:in `block in initialize'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/util/profiler/around_profiler.rb:58:in `profile'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/util/profiler.rb:51:in `profile'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/catalog/compiler.rb:68:in `initialize'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/indirection.rb:334:in `new'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/indirection.rb:334:in `make_terminus'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/indirection.rb:123:in `terminus'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/indirection.rb:321:in `prepare'
     # ./.bundle/ruby/2.4.0/gems/puppet-5.3.2/lib/puppet/indirector/indirection.rb:185:in `find'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/adapters.rb:83:in `catalog'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/adapters.rb:161:in `catalog'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:355:in `build_catalog_without_cache'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:376:in `block in build_catalog'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/cache.rb:17:in `get'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:375:in `build_catalog'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:75:in `block in load_catalogue'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:319:in `with_vardir'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:69:in `load_catalogue'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/example/class_example_group.rb:7:in `catalogue'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/support.rb:10:in `block in subject'
     # ./.bundle/ruby/2.4.0/gems/rspec-puppet-2.6.9/lib/rspec-puppet/matchers/compile.rb:23:in `matches?'
     # ./spec/classes/role/sqlserver_spec.rb:27:in `block (3 levels) in <top (required)>'
```



