### PR TITLE
(#632) Support testing symlink File resources for Windows on non-windows

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -287,6 +287,16 @@ Puppet::Type.type(:file).provide(:windows).class_eval do
       old_supports_acl.bind(self).call(value)
     end
   end
+
+  old_manages_symlinks = instance_method(:manages_symlinks?) if respond_to?(:manages_symlinks?)
+
+  def manages_symlinks?
+    if RSpec::Puppet.rspec_puppet_example?
+      true
+    else
+      old_manages_symlinks.bind(self).call(value)
+    end
+  end
 end
 
 # Prevent Puppet from requiring 'puppet/util/windows' if we're pretending to be

--- a/spec/classes/test_windows_spec.rb
+++ b/spec/classes/test_windows_spec.rb
@@ -4,4 +4,5 @@ describe 'test::windows' do
   let(:facts) { {:operatingsystem => 'windows' } }
 
   it { should compile.with_all_deps }
+  it { should contain_file('C:\\something.txt') }
 end

--- a/spec/classes/test_windows_spec.rb
+++ b/spec/classes/test_windows_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'test::windows' do
   let(:facts) { {:operatingsystem => 'windows' } }
 
+  let(:symlink_path) do
+    RUBY_VERSION == '1.8.7' ? 'C:\\\\something.txt' : 'C:\\something.txt'
+  end
+
   it { should compile.with_all_deps }
-  it { should contain_file('C:\\something.txt') }
+  it { should contain_file(symlink_path) }
 end

--- a/spec/fixtures/modules/test/manifests/windows.pp
+++ b/spec/fixtures/modules/test/manifests/windows.pp
@@ -6,6 +6,11 @@ class test::windows {
     provider => windows,
   }
 
+  file { 'C:\\something.txt':
+    ensure => link,
+    target => 'C:\\test.txt',
+  }
+
   package { 'test':
     ensure => 'installed',
   }


### PR DESCRIPTION
Stubs out the `manages_symlinks?` method on the `windows` file provider as this can not be correctly evaluated at compile time.

Fixes #632