### PR TITLE
(#614) Check that data types match if expected is Array or Hash

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -87,6 +87,11 @@ module RSpec::Puppet
       def check_hash(expected, actual)
         op = @should_match ? :"==" : :"!="
 
+        unless actual.class.send(op, expected.class)
+          @errors << MatchError.new(@parameter, expected, actual, !@should_match)
+          return false
+        end
+
         unless expected.keys.size.send(op, actual.keys.size)
           return false
         end
@@ -98,6 +103,11 @@ module RSpec::Puppet
 
       def check_array(expected, actual)
         op = @should_match ? :"==" : :"!="
+
+        unless actual.class.send(op, expected.class)
+          @errors << MatchError.new(@parameter, expected, actual, !@should_match)
+          return false
+        end
 
         unless expected.size.send(op, actual.size)
           return false

--- a/spec/classes/type_mismatch_spec.rb
+++ b/spec/classes/type_mismatch_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'type_mismatch', :if => Puppet.version.to_f >= 4.0 do
+  it { should compile.with_all_deps }
+
+  it do
+    should_not contain_type_mismatch__hash('bug').with_hash(
+      'foo' => {
+        'bar' => {},
+      }
+    )
+  end
+
+  it do
+    expect {
+      should_not contain_type_mismatch__hash('bug').with_hash(
+        'foo' => {
+          'bar' => {},
+        }
+      )
+    }.to_not raise_error
+  end
+end

--- a/spec/fixtures/modules/type_mismatch/manifests/hash.pp
+++ b/spec/fixtures/modules/type_mismatch/manifests/hash.pp
@@ -1,0 +1,4 @@
+define type_mismatch::hash(
+  Hash[String, Hash] $hash,
+) {
+}

--- a/spec/fixtures/modules/type_mismatch/manifests/init.pp
+++ b/spec/fixtures/modules/type_mismatch/manifests/init.pp
@@ -1,0 +1,11 @@
+class type_mismatch {
+  $hash = {
+    'foo' => {
+      'bar' => [],
+    },
+  }
+
+  type_mismatch::hash { 'bug':
+    hash => $hash,
+  }
+}


### PR DESCRIPTION
Prevents potential unhandled exceptions when the expected value of an attribute is an array or a hash. The check logic for these cases use class specific methods (like `Hash#key`) which generally aren't available on other classes.

Fixes #614