### PR TITLE
Add support for setting 'server_facts' via rspec-puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Boolean | `false` | >=3.4, 4.x, 5.x
 Configures rspec-puppet to use the `$trusted` hash when compiling the
 catalogues.
 
+#### trusted\_server\_facts
+Type    | Default | Puppet Version(s)
+------- | ------- | -----------------
+Boolean | `false` | >=4.3, 5.x
+
+Configures rspec-puppet to use the `$server_facts` hash when compiling the
+catalogues.
+
 #### confdir
 Type   | Default         | Puppet Version(s)
 ------ | --------------- | ------------------

--- a/docs/documentation/configuration/index.md
+++ b/docs/documentation/configuration/index.md
@@ -77,6 +77,14 @@ Makes rspec-puppet use the `$trusted` hash when testing catalogues.
 Configures rspec-puppet to automatically create a link from the root of your
 module to `spec/fixtures/<module name>` at the beginning of the test run.
 
+### trusted\_server\_facts
+**Type:** Boolean<br />
+**Default:** `false`<br />
+**Puppet Version(s):** >= 4.3, 5.x
+
+Configures rspec-puppet to use the `$server_facts` hash when compiling the
+catalogues.
+
 ## Optional overrides
 Only set these values if you need to. rspec-puppet is generally pretty good at
 determining the values itself, but if you need to override them you can.

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -23,6 +23,10 @@ module RSpec::Puppet
   def self.rspec_puppet_example?
     RSpec::Puppet::EventListener.rspec_puppet_example?
   end
+
+  def self.current_example
+    RSpec::Puppet::EventListener.current_example
+  end
 end
 
 require 'rspec-puppet/monkey_patches'
@@ -48,7 +52,17 @@ RSpec.configure do |c|
   c.add_setting :derive_node_facts_from_nodename, :default => true
   c.add_setting :adapter
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
-  c.add_setting :trusted_server_facts, :default => false
+
+  c.instance_eval do
+    def trusted_server_facts
+      @trusted_server_facts.nil? ? false : @trusted_server_facts
+    end
+
+    def trusted_server_facts=(value)
+      @trusted_server_facts = value
+      adapter.setup_puppet(RSpec::Puppet.current_example) unless adapter.nil?
+    end
+  end
 
   c.before(:all) do
     if RSpec.configuration.setup_fixtures?

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -48,6 +48,7 @@ RSpec.configure do |c|
   c.add_setting :derive_node_facts_from_nodename, :default => true
   c.add_setting :adapter
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
+  c.add_setting :trusted_server_facts, :default => false
 
   c.before(:all) do
     if RSpec.configuration.setup_fixtures?

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -150,6 +150,7 @@ module RSpec::Puppet
           [:hiera_config, :hiera_config],
           [:strict_variables, :strict_variables],
           [:manifest, :manifest],
+          [:trusted_server_facts, :trusted_server_facts]
         ])
       end
 

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -11,8 +11,13 @@ class RSpec::Puppet::EventListener
   def self.example_started(example)
     if rspec3?
       @rspec_puppet_example = example.example.example_group.ancestors.include?(RSpec::Puppet::Support)
+      @current_example = example.example
+      if !@current_example.respond_to?(:environment) && @current_example.respond_to?(:example_group_instance)
+        @current_example = @current_example.example_group_instance
+      end
     else
       @rspec_puppet_example = example.example_group.ancestors.include?(RSpec::Puppet::Support)
+      @current_example = example
     end
   end
 
@@ -38,6 +43,10 @@ class RSpec::Puppet::EventListener
     end
 
     @rspec3
+  end
+
+  def self.current_example
+    @current_example
   end
 end
 

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -279,7 +279,7 @@ module RSpec::Puppet
       extensions
     end
 
-    def server_facts_hash()
+    def server_facts_hash
       server_facts = {}
 
       # Add our server version to the fact list

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -74,7 +74,8 @@ module RSpec::Puppet
 
         build_facts = facts_hash(node_name)
         catalogue = build_catalog(node_name, build_facts, trusted_facts_hash(node_name), hiera_config_value,
-                                  build_code(type, manifest_opts), exported, node_params_hash, hiera_data_value)
+                                  build_code(type, manifest_opts), exported, node_params_hash, hiera_data_value,
+                                  RSpec.configuration.trusted_server_facts)
 
         test_module = type == :host ? nil : class_name.split('::').first
         if type == :define

--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -292,7 +292,7 @@ module RSpec::Puppet
         if value = Facter.value(fact)
           server_facts[var] = value
         else
-          Puppet.warning _("Could not retrieve fact %{fact}") % { fact: fact }
+          warn "Could not retrieve fact #{fact}"
         end
       end
 

--- a/spec/classes/server_facts_spec.rb
+++ b/spec/classes/server_facts_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'server_facts', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 do
+
+  context 'with server_facts' do
+    before do
+      RSpec.configuration.trusted_server_facts = true
+    end
+
+    let(:node) { 'test123.test.com' }
+    it { should contain_class('server_facts') }
+    it { should compile.with_all_deps }
+    it { should contain_notify("servername-test123.test.com") }
+    it { should contain_notify("serverip-192.168.1.50") }
+    it { should contain_notify("serverversion-4.10.9") }
+    it { should contain_notify("environment-rp_env") }
+  end
+end

--- a/spec/classes/server_facts_spec.rb
+++ b/spec/classes/server_facts_spec.rb
@@ -7,12 +7,17 @@ describe 'server_facts', :if => Puppet::Util::Package.versioncmp(Puppet.version,
       RSpec.configuration.trusted_server_facts = true
     end
 
+    let(:facts) {
+      {
+        :ipaddress => '192.168.1.10'
+      }
+    }
     let(:node) { 'test123.test.com' }
     it { should contain_class('server_facts') }
     it { should compile.with_all_deps }
     it { should contain_notify("servername-test123.test.com") }
-    it { should contain_notify("serverip-192.168.1.50") }
-    it { should contain_notify("serverversion-4.10.9") }
+    it { should contain_notify("serverip-192.168.1.10") }
+    it { should contain_notify("serverversion-#{Puppet.version}") }
     it { should contain_notify("environment-rp_env") }
   end
 end

--- a/spec/fixtures/modules/server_facts/manifests/init.pp
+++ b/spec/fixtures/modules/server_facts/manifests/init.pp
@@ -1,0 +1,7 @@
+class server_facts {
+  notify { "servername-${server_facts['servername']}": }
+  notify { "serverip-${server_facts['serverip']}": }
+  notify { "serverversion-${server_facts['serverversion']}": }
+  notify { "environment-${server_facts['environment']}": }
+}
+


### PR DESCRIPTION
This change sets the `$server_facts` variable when testing via rspec-puppet.

TODO: 
- [ ] Tests?
- [x] Documentation

Fixes #642 