### PR TITLE
(#615) Ensure resource under test is marked as covered

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -119,6 +119,8 @@ module RSpec::Puppet
     def results
       report = {}
 
+      @collection.delete_if { |name, _| filtered?(name) }
+
       report[:total] = @collection.size
       report[:touched] = @collection.count { |_, resource| resource.touched? }
       report[:untouched] = report[:total] - report[:touched]


### PR DESCRIPTION
When a class that inherits another class is tested before the inherited class is tested, it can cause a false uncovered resource in the coverage report. This is because in the earlier test, the inherited class is not automatically filtered out of the coverage report as the resource under test is, and then later when the inherited class is tested it is added to the filter but the resource is already in the coverage report as an untouched resource.

This change makes a second pass through the resource coverage report when calculating the result, removing any filtered out resources that got added before they were filtered out.

Fixes #615