### PR TITLE
Only prepare server_facts hash if trusted_server_facts is enabled

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -400,10 +400,8 @@ module RSpec::Puppet
           },
           "Context for spec trusted hash"
         )
-      end
 
-      if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0
-        node_obj.add_server_facts(server_facts_hash)
+        node_obj.add_server_facts(server_facts_hash) if RSpec.configuration.trusted_server_facts
       end
 
       adapter.catalog(node_obj, exported)

--- a/lib/rspec-puppet/tasks/release_test.rb
+++ b/lib/rspec-puppet/tasks/release_test.rb
@@ -17,6 +17,7 @@ task :release_test do
     'garethr/garethr-docker',
     'sensu/sensu-puppet',
     'jenkinsci/puppet-jenkins',
+    'rnelson0/puppet-local_user',
   ]
 
   Bundler.with_clean_env do


### PR DESCRIPTION
This fixes up the issue in 2.6.10 that @rnelson0 raised in #599.