### PR TITLE
allow testing environment functions

### DIFF
--- a/lib/rspec-puppet/example/function_example_group.rb
+++ b/lib/rspec-puppet/example/function_example_group.rb
@@ -87,6 +87,18 @@ module RSpec::Puppet
           context_overrides = compiler.context_overrides
           func = nil
           loaders = Puppet.lookup(:loaders)
+
+          # allow loading functions from the environment
+          Puppet.override(context_overrides, "rspec-test scope") do
+            # TODO a better way to get the base directory (don't assume)
+            dir = File.join(Dir.pwd, 'lib')
+            loader = Puppet::Pops::Loader::ModuleLoaders::FileBased.new(loaders.private_environment_loader, loaders, Puppet::Pops::Loader::ENVIRONMENT, dir, 'environment functions', [:func_4x])
+            func = V4FunctionWrapper.new(function_name, loader.load(:function, function_name), context_overrides)
+            @scope = context_overrides[:global_scope]
+          end
+
+          return func if func.func
+
           Puppet.override(context_overrides, "rspec-test scope") do
             func = V4FunctionWrapper.new(function_name, loaders.private_environment_loader.load(:function, function_name), context_overrides)
             @scope = context_overrides[:global_scope]


### PR DESCRIPTION
This is probably the wrong way to achieve the outcome, it's just what I did to get it working and figured it should be shared.

# Scenario
 As per https://puppet.com/docs/puppet/5.3/functions_ruby_overview.html#location I have an "environment function" named `environment::upcase` and I want to test it.  My test code looks like

 ```
require 'spec_helper'

describe 'environment::upcase' do
  it {
    should run.with_params("a").and_return("A")
  }
end
```

# Issue
 Running the tests as-is fails with
```
     NoMethodError:
       undefined method `func_name' for nil:NilClass
     # ./vendor/gems/ruby/gems/rspec-puppet-2.6.11/lib/rspec-puppet/matchers/run.rb:109:in `func_name'
     # ./vendor/gems/ruby/gems/rspec-puppet-2.6.11/lib/rspec-puppet/matchers/run.rb:135:in `failure_message_generic'
     # ./vendor/gems/ruby/gems/rspec-puppet-2.6.11/lib/rspec-puppet/matchers/run.rb:92:in `failure_message'
     # ./spec/functions/environment__upcase_spec.rb:25:in `block (2 levels) in <top (required)>'
```

# Workaround
 This MR allows the test to succeed

 ```
# bundle exec rspec
....

Finished in 0.51518 seconds (files took 8.41 seconds to load)
1 examples, 0 failures
```