### PR TITLE
puppetlabs-acl: monkey patch for non-windows o/s

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -158,6 +158,15 @@ module Puppet
       module_function :get_env
     end
 
+    module Windows
+      module File
+        def symlink?(file_name)
+          false
+        end
+        module_function :symlink?
+      end
+    end
+
     # Allow rspec-puppet to pretend to be different platforms.
     module Platform
       alias :old_windows? :windows?


### PR DESCRIPTION
This simply monkey patches the Puppet::Util::Windows::File Modules symlink? method so that on non-windows OS when running rspec-puppet on puppet code that is utilizing the puppetlabs-acl type the windows specific code it's looking for is not undefined. Any feedback is appreciated and/or changed that should be made.

Fixes #665 

/cc @rodjek 