### PR TITLE
fix Puppet 3 map/reduce

### DIFF
--- a/lib/rspec-puppet/setup.rb
+++ b/lib/rspec-puppet/setup.rb
@@ -1,7 +1,4 @@
 require 'puppet'
-if Puppet.version.to_f >= 4.0
-  require 'puppet/pops'
-end
 require 'fileutils'
 
 module RSpec::Puppet
@@ -87,7 +84,8 @@ END
     def self.get_module_name_from_file(file)
       # FIXME: see discussion at
       # https://github.com/rodjek/rspec-puppet/issues/290
-      if Puppet.version.to_f >= 4.0
+      if Puppet.version.to_f >= 4.0 || RSpec.configuration.parser == 'future'
+        require 'puppet/pops'
         p = Puppet::Pops::Parser::Lexer2.new
       else
         p = Puppet::Parser::Lexer.new

--- a/spec/classes/map_reduce_spec.rb
+++ b/spec/classes/map_reduce_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'map_reduce', :if => (Puppet.version.to_f >= 4.0 || RSpec.configuration.parser == 'future') do
+  let(:params) do
+    {
+     :values => [0, 1, 2]
+    }
+  end
+
+  it { should compile.with_all_deps }
+
+  it { should create_notify('joined_incremented_values').with_message('123') }
+end

--- a/spec/fixtures/modules/map_reduce/manifests/init.pp
+++ b/spec/fixtures/modules/map_reduce/manifests/init.pp
@@ -1,0 +1,9 @@
+class map_reduce (
+  Array[Integer] $values
+) {
+  $incremented_values = $values.map |$x| { $x + 1 }
+  $result = $incremented_values.reduce('') |$memo, $x| { "${memo}${x}" }
+  notify { 'joined_incremented_values':
+    message => $result,
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |c|
   c.manifest_dir    = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests')
   c.manifest        = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'manifests', 'site.pp')
   c.environmentpath = File.join(Dir.pwd, 'spec')
+  c.parser          = ENV['FUTURE_PARSER'] == 'yes' ? 'future' : 'current'
 
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!(0)


### PR DESCRIPTION
- (5bdb7e7cda1fd46b8043087201b02f03d24b1b5a) add test for map/reduce functions
  This adds a test to exercise the map and reduce syntax which requires the
  future parser or Puppet 4+.

- (010afc315b2e809c75665169e9de1ab48f446a18) use the correct Lexer for the future parser
  This fixes a bug that occurs when processing certain future parser compliant 
  text on Puppet < 4.0 by switching to the newer lexer when the future parser is 
  enabled.

I'm not sure if the change I made to `spec_helper.rb` is the best route to get the future parser tested (using the `FUTURE_PARSER` environment variable), but this definitely fixes issues parsing newer style code on Puppet 3.  If you still care about Puppet 3 compatibility, it wouldn't hurt to add this combination of environment vars to the automated testing as well.