### PR TITLE
(MODULES-6978) only look in 'os' fact if 'os' is a hash

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -63,7 +63,7 @@ module RSpec::Puppet
         value.to_s.downcase == 'windows' ? :windows : :posix
       }
 
-      ['operatingsystem', 'osfamily', 'os'].each do |os_fact|
+      ['operatingsystem', 'osfamily'].each do |os_fact|
         return from_value.call(test_facts[os_fact]) if test_facts.key?(os_fact)
       end
 

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -60,6 +60,50 @@ describe RSpec::Puppet::Support do
     end
   end
 
+  describe '#find_pretend_platform' do
+    let(:build_hash) do
+      {
+	"hostname" => "fy73bdiqazmyj62",
+	"networking" => {
+	  "hostname" => "fy73bdiqazmyj62",
+	  "fqdn" => "fy73bdiqazmyj62.delivery.puppetlabs.net"
+	},
+      }
+    end
+    context 'without os facts' do
+      it 'returns the correct platform' do
+	expect(subject.find_pretend_platform(build_hash)).to eq(nil)
+      end
+    end
+    { 'windows' => :windows, 'debian' => :posix }.each do |family, platform|
+      context 'with os structured fact' do
+	let(:build_hash) do
+	  super().merge({
+	    "os" => {
+	      "family" => family,
+	      "version" => {
+		"major" => "10"
+	      }
+	    }
+	  })
+	end
+	it 'returns the correct platform' do
+	  expect(subject.find_pretend_platform(build_hash)).to eq(platform)
+	end
+      end
+      context 'with osfamily fact' do
+	let(:build_hash) do
+	  super().merge({
+	    "osfamily" => family
+	  })
+	end
+	it 'returns the correct platform' do
+	  expect(subject.find_pretend_platform(build_hash)).to eq(platform)
+	end
+      end
+    end
+  end
+
   describe '#build_code' do
     before do
       class << subject


### PR DESCRIPTION
I have been working on a failure in the puppetlabs-inifile unit tests
recently and found out that rspec-puppet may be looking in the wrong
place when setting the 'pretend_platform' for tests. In the line changed, 'os'
should be ommitted and and then handled below where it is instead
evaluated as a hash. So that if you use structured facts in your tests,
it will not look in 'os', find a hash, then default to posix because a
hash is not 'windows', instead of waiting to look at ['os']['family'].