### PR TITLE
Default paths to platform appropriate null paths

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -32,17 +32,17 @@ end
 require 'rspec-puppet/monkey_patches'
 
 RSpec.configure do |c|
-  c.add_setting :environmentpath, :default => '/etc/puppetlabs/code/environments'
+  c.add_setting :environmentpath, :default => Puppet::Util::Platform.actually_windows? ? 'nul' : '/dev/null'
   c.add_setting :module_path, :default => nil
   c.add_setting :manifest_dir, :default => nil
   c.add_setting :manifest, :default => nil
   c.add_setting :template_dir, :default => nil
   c.add_setting :config, :default => nil
-  c.add_setting :confdir, :default => '/etc/puppet'
+  c.add_setting :confdir, :default => Puppet::Util::Platform.actually_windows? ? 'nul' : '/dev/null'
   c.add_setting :default_facts, :default => {}
   c.add_setting :default_node_params, :default => {}
   c.add_setting :default_trusted_facts, :default => {}
-  c.add_setting :hiera_config, :default => '/dev/null'
+  c.add_setting :hiera_config, :default => Puppet::Util::Platform.actually_windows? ? 'nul' : '/dev/null'
   c.add_setting :parser, :default => 'current'
   c.add_setting :trusted_node_data, :default => false
   c.add_setting :ordering, :default => 'title-hash'

--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -32,17 +32,17 @@ end
 require 'rspec-puppet/monkey_patches'
 
 RSpec.configure do |c|
-  c.add_setting :environmentpath, :default => Puppet::Util::Platform.actually_windows? ? 'nul' : '/dev/null'
+  c.add_setting :environmentpath, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :module_path, :default => nil
   c.add_setting :manifest_dir, :default => nil
   c.add_setting :manifest, :default => nil
   c.add_setting :template_dir, :default => nil
   c.add_setting :config, :default => nil
-  c.add_setting :confdir, :default => Puppet::Util::Platform.actually_windows? ? 'nul' : '/dev/null'
+  c.add_setting :confdir, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :default_facts, :default => {}
   c.add_setting :default_node_params, :default => {}
   c.add_setting :default_trusted_facts, :default => {}
-  c.add_setting :hiera_config, :default => Puppet::Util::Platform.actually_windows? ? 'nul' : '/dev/null'
+  c.add_setting :hiera_config, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :parser, :default => 'current'
   c.add_setting :trusted_node_data, :default => false
   c.add_setting :ordering, :default => 'title-hash'

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -47,7 +47,7 @@ module RSpec::Puppet
           default_hash.merge!(Puppet::Test::TestHelper.send(:app_defaults_for_tests))
         end
         settings_hash = default_hash.merge(Hash[*settings])
-        settings_hash.inject(settings_hash) { |h, (k, v)| h[k] = (v == '/dev/null') ? 'nul' : v; h } if Gem.win_platform?
+        settings_hash.inject(settings_hash) { |h, (k, v)| h[k] = (v == '/dev/null') ? 'c:/nul/' : v; h } if Gem.win_platform?
 
         if Puppet.settings.respond_to?(:initialize_app_defaults)
           Puppet.settings.initialize_app_defaults(settings_hash)

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -47,6 +47,7 @@ module RSpec::Puppet
           default_hash.merge!(Puppet::Test::TestHelper.send(:app_defaults_for_tests))
         end
         settings_hash = default_hash.merge(Hash[*settings])
+        settings_hash.inject(settings_hash) { |h, (k, v)| h[k] = (v == '/dev/null') ? 'nul' : v; h } if Gem.win_platform?
 
         if Puppet.settings.respond_to?(:initialize_app_defaults)
           Puppet.settings.initialize_app_defaults(settings_hash)

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -178,6 +178,11 @@ module Puppet
       end
       module_function :actual_platform
 
+      def actually_windows?
+        actual_platform == :windows
+      end
+      module_function :actually_windows?
+
       def pretend_windows?
         pretend_platform == :windows
       end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -15,6 +15,20 @@ describe RSpec::Puppet::Adapters::Base do
     end
   end
 
+  describe 'default settings' do
+    before do
+      subject.setup_puppet(context_double)
+    end
+
+    null_path = windows? ? 'nul' : '/dev/null'
+
+    [:vardir, :confdir].each do |setting|
+      it "sets #{setting} to #{null_path}" do
+        expect(Puppet[setting]).to eq(File.expand_path(null_path))
+      end
+    end
+  end
+
   describe '#set_setting' do
     describe "with a context specific setting" do
       it "sets the Puppet setting based on the example group setting" do
@@ -29,7 +43,7 @@ describe RSpec::Puppet::Adapters::Base do
         subject.setup_puppet(context1)
         expect(Puppet[:confdir]).to match(%r{(C:)?/etc/fingerpuppet})
         subject.setup_puppet(context2)
-        expect(Puppet[:confdir]).to match(%r{(C:)?/etc/puppet})
+        expect(Puppet[:confdir]).not_to match(%r{(C:)?/etc/fingerpuppet})
       end
     end
 
@@ -149,6 +163,19 @@ describe RSpec::Puppet::Adapters::Adapter32, :if => (3.2 ... 4.0).include?(Puppe
     end
   end
 
+  describe 'default settings' do
+    before do
+      subject.setup_puppet(context_double)
+    end
+
+    null_path = windows? ? 'nul' : '/dev/null'
+
+    [:vardir, :rundir, :logdir, :hiera_config, :confdir].each do |setting|
+      it "sets #{setting} to #{null_path}" do
+        expect(Puppet[setting]).to eq(File.expand_path(null_path))
+      end
+    end
+  end
 end
 
 describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 do
@@ -184,6 +211,20 @@ describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 d
       allow(RSpec.configuration).to receive(:environmentpath).and_return("/some/missing/path:/another/missing/path")
       subject.setup_puppet(double(:environment => 'rp_puppet'))
       expect(subject.manifest).to be_nil
+    end
+  end
+
+  describe 'default settings' do
+    before do
+      subject.setup_puppet(context_double)
+    end
+
+    null_path = windows? ? 'nul' : '/dev/null'
+
+    [:vardir, :codedir, :rundir, :logdir, :hiera_config, :confdir].each do |setting|
+      it "sets #{setting} to #{null_path}" do
+        expect(Puppet[setting]).to eq(File.expand_path(null_path))
+      end
     end
   end
 end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -20,7 +20,7 @@ describe RSpec::Puppet::Adapters::Base do
       subject.setup_puppet(context_double)
     end
 
-    null_path = windows? ? 'nul' : '/dev/null'
+    null_path = windows? ? 'c:/nul/' : '/dev/null'
 
     [:vardir, :confdir].each do |setting|
       it "sets #{setting} to #{null_path}" do
@@ -168,7 +168,7 @@ describe RSpec::Puppet::Adapters::Adapter32, :if => (3.2 ... 4.0).include?(Puppe
       subject.setup_puppet(context_double)
     end
 
-    null_path = windows? ? 'nul' : '/dev/null'
+    null_path = windows? ? 'c:/nul/' : '/dev/null'
 
     [:vardir, :rundir, :logdir, :hiera_config, :confdir].each do |setting|
       it "sets #{setting} to #{null_path}" do
@@ -219,7 +219,7 @@ describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 d
       subject.setup_puppet(context_double)
     end
 
-    null_path = windows? ? 'nul' : '/dev/null'
+    null_path = windows? ? 'c:/nul/' : '/dev/null'
 
     [:vardir, :codedir, :rundir, :logdir, :hiera_config, :confdir].each do |setting|
       it "sets #{setting} to #{null_path}" do


### PR DESCRIPTION
* Changes the default `environmentpath` and `confdir` values to default to null paths (`nul` on windows, `/dev/null` otherwise). This will probably be a breaking change for a handful of people that run rspec-puppet tests directly on their puppet masters and rely on these default values, but the benefit of allowing non-Administrator Windows users to run tests outweighs this.
* Also changes the `/dev/null` values from `Puppet::Test::TestHelper` into `nul` when running rspec-puppet on Windows, preventing Puppet from creating empty `C:\dev` directories when running tests.

Fixes #686