### PR TITLE
(#669) Filter default resources from catalogue in have_resource_count matcher

### DIFF
--- a/spec/classes/test_empty_class_spec.rb
+++ b/spec/classes/test_empty_class_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'test::empty_class' do
+  it { should compile }
+
+  context 'exported resources' do
+    subject { exported_resources }
+
+    it { should have_resource_count(0) }
+  end
+end

--- a/spec/fixtures/modules/test/manifests/empty_class.pp
+++ b/spec/fixtures/modules/test/manifests/empty_class.pp
@@ -1,0 +1,2 @@
+class test::empty_class {
+}


### PR DESCRIPTION
Remove the default resources (`Stage[main]`, `Class[main]`, and
`Class[Settings]` from catalogue when running the `have_resource_count`
matcher rather than simply subtracting the expected number from the
count. This will allow the matcher to be used on the
`exported_resources` subject, which doesn't generally include these
default resources.

Fixes #669