### PR TITLE
Stub Selinux.is_selinux_enabled to return 0

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -120,6 +120,7 @@ RSpec.configure do |c|
     if RSpec::Puppet.rspec_puppet_example?
       Puppet::Util::Platform.pretend_to_be RSpec.configuration.platform
       stub_file_consts(example) if self.respond_to?(:stub_file_consts)
+      allow(Selinux).to receive(:is_selinux_enabled).and_return(0) if defined?(Selinux)
     end
   end
 


### PR DESCRIPTION
SELinux checks only make sense when applying the catalogue, so this can be safely disabled for all tests.

Fixes #674 