### PR TITLE
Expecting undef parameters with only_with should not affect expected parameter count

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -30,7 +30,7 @@ module RSpec::Puppet
 
       def only_with(*args, &block)
         params = args.shift
-        @expected_params_count = (@expected_params_count || 0) + params.size
+        @expected_params_count = (@expected_params_count || 0) + params.select { |_, v| !v.nil? }.size
         self.with(params, &block)
       end
 

--- a/spec/classes/undef_spec.rb
+++ b/spec/classes/undef_spec.rb
@@ -10,6 +10,17 @@ describe 'undef_test' do
       it { should contain_class('undef_test').with(:required_attribute => 'some_string') }
 
       it { should contain_class('undef_test').without_defaults_to_undef }
+
+      it 'does not include undef parameters in the parameter count matcher' do
+        res = catalogue.resource('Class', 'undef_test').to_hash.dup
+        res.delete(:name)
+        res.size.should eq(1)
+
+        should contain_class('undef_test').only_with(
+          :required_attribute => 'some_string',
+          :defaults_to_undef  => nil
+        )
+      end
     end
 
     context 'and defaults_to_undef => :undef' do
@@ -20,6 +31,17 @@ describe 'undef_test' do
       it { should contain_class('undef_test').with(:required_attribute => 'some_string') }
 
       it { should contain_class('undef_test').without_defaults_to_undef }
+
+      it 'does not include undef parameters in the parameter count matcher' do
+        res = catalogue.resource('Class', 'undef_test').to_hash.dup
+        res.delete(:name)
+        res.size.should eq(1)
+
+        should contain_class('undef_test').only_with(
+          :required_attribute => 'some_string',
+          :defaults_to_undef  => nil
+        )
+      end
     end
   end
 
@@ -32,6 +54,17 @@ describe 'undef_test' do
       it { should contain_class('undef_test').without_required_attribute }
 
       it { should contain_class('undef_test').without_defaults_to_undef }
+
+      it 'does not include undef parameters in the parameter count matcher' do
+        res = catalogue.resource('Class', 'undef_test').to_hash.dup
+        res.delete(:name)
+        res.size.should eq(0)
+
+        should contain_class('undef_test').only_with(
+          :required_attribute => nil,
+          :defaults_to_undef  => nil
+        )
+      end
     end
 
     context 'and defaults_to_undef => :undef' do
@@ -42,6 +75,17 @@ describe 'undef_test' do
       it { should contain_class('undef_test').without_required_attribute }
 
       it { should contain_class('undef_test').without_defaults_to_undef }
+
+      it 'does not include undef parameters in the parameter count matcher' do
+        res = catalogue.resource('Class', 'undef_test').to_hash.dup
+        res.delete(:name)
+        res.size.should eq(0)
+
+        should contain_class('undef_test').only_with(
+          :required_attribute => nil,
+          :defaults_to_undef  => nil
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Found this regression when running the 2.6.12 rc build against jenkins/puppet-jenkins.

e.g.
`it { is_expected.to contain_foo('bar').only_with(:baz => nil) }` should have an expected parameter count of 0, not 1.