### PR TITLE
(#712) Remove trusted_server_facts setting for Puppet 6.x

### DIFF
--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -192,6 +192,8 @@ module RSpec::Puppet
       end
     end
 
+    class Adapter6X < Adapter40; end
+
     class Adapter30 < Base
       def settings_map
         super.concat([
@@ -248,6 +250,7 @@ module RSpec::Puppet
 
     def self.get
       [
+        ['6.0', Adapter6X],
         ['4.1', Adapter4X],
         ['4.0', Adapter40],
         ['3.5', Adapter35],

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -178,7 +178,7 @@ describe RSpec::Puppet::Adapters::Adapter32, :if => (3.2 ... 4.0).include?(Puppe
   end
 end
 
-describe RSpec::Puppet::Adapters::Adapter4X, :if => Puppet.version.to_f >= 4.0 do
+describe RSpec::Puppet::Adapters::Adapter4X, :if => (4.0 ... 6.0).include?(Puppet.version.to_f) do
 
   let(:test_context) { double :environment => 'rp_env' }
 


### PR DESCRIPTION
This setting has been dropped in Puppet 6.

Fixes #712 