### PR TITLE
Autosign setting is deprecated in puppet 5.5.6

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -408,7 +408,6 @@ module RSpec::Puppet
     end
 
     def stub_facts!(facts)
-      Puppet.settings[:autosign] = false
       Facter.clear
       facts.each { |k, v| Facter.add(k, :weight => 999) { setcode { v } } }
     end


### PR DESCRIPTION
This can be seen in https://travis-ci.org/puppetlabs/puppetlabs-stdlib/jobs/419519302