### PR TITLE
Only set :autosign if the setting exists

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -408,7 +408,7 @@ module RSpec::Puppet
     end
 
     def stub_facts!(facts)
-      Puppet.settings[:autosign] = false
+      Puppet.settings[:autosign] = false if Puppet.settings.include? :autosign
       Facter.clear
       facts.each { |k, v| Facter.add(k, :weight => 999) { setcode { v } } }
     end


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/PUP-3648 for discussion. This setting is deprecated and will be removed in Puppet 6