### PR TITLE
Patch service to default to systemd on Debian 9

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -315,6 +315,18 @@ Puppet::Type.type(:file).provide(:windows).class_eval do
   end
 end
 
+# Puppet 4.8 systemd provider does not recognize Debian 9 (Stretch). It fall
+# back to runit which causes:
+#   Could not find the daemon directory (tested [/etc/sv,/var/lib/service])
+# The Debian package is patched, but the gem 4.8.2 is not.
+# Support has been added in Puppet 4.10.0:
+# https://github.com/puppetlabs/puppet/commit/d5a69fb57c15683873b422cb5e17ef06ca13cea5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.8.0') >= 0 && Puppet::Util::Package.versioncmp(Puppet.version, '4.10.0') < 0
+  Puppet::Type.type(:service).provide(:systemd).instance_eval do
+    defaultfor :operatingsystem => :debian
+  end
+end
+
 # Prevent Puppet from requiring 'puppet/util/windows' if we're pretending to be
 # windows, otherwise it will require other libraries that probably won't be
 # available on non-windows hosts.

--- a/spec/classes/test_multi_os.rb
+++ b/spec/classes/test_multi_os.rb
@@ -23,5 +23,12 @@ describe 'test::multi_os' do
     it 'sets the provider of the File resource to :posix' do
       catalogue.resource('file', '/test').to_ral.provider.class.name.should eq(:posix)
     end
+
+    describe "service resource" do
+      let (:pre_condition) { 'service { "foo": }' }
+      it 'sets provider to systemd' do
+        catalogue.resource('service', 'foo').to_ral.provider.class.name.should eq(:systemd)
+      end
+    end
   end
 end


### PR DESCRIPTION
Puppet 4.8.x systemd provider does not recognize Debian 9 (Stretch), it
thus fall back to runit and the spec fails with:

  Could not find the daemon directory (tested [/etc/sv,/var/lib/service])

Tested using:

 PUPPET_GEM_VERSION='4.8.2' bundle install
 bundle exec rspec ./spec/classes/relationship__titles_spec.rb

References:
https://github.com/puppetlabs/puppet/commit/d5a69fb57c15683873b422cb5e17ef06ca13cea5
https://phabricator.wikimedia.org/T203645