### PR TITLE
(MODULES-7854) Stub out default values for puppet6

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -52,6 +52,8 @@ RSpec.configure do |c|
   c.add_setting :derive_node_facts_from_nodename, :default => true
   c.add_setting :adapter
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
+  c.add_setting :vendormoduledir, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
+  c.add_setting :basemodulepath, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
 
   c.instance_eval do
     def trusted_server_facts

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -192,7 +192,14 @@ module RSpec::Puppet
       end
     end
 
-    class Adapter6X < Adapter40; end
+    class Adapter6X < Adapter40
+      def settings_map
+        super.concat([
+          [:basemodulepath, :basemodulepath],
+          [:vendormoduledir, :vendormoduledir],
+        ])
+      end
+    end
 
     class Adapter30 < Base
       def settings_map

--- a/lib/rspec-puppet/consts.rb
+++ b/lib/rspec-puppet/consts.rb
@@ -12,9 +12,24 @@ module RSpec::Puppet::Consts
     }
   }
 
+  FEATURES = {
+    :posix   => {
+      :posix             => true,
+      :microsoft_windows => false,
+    },
+    :windows => {
+      :posix             => false,
+      :microsoft_windows => true,
+    },
+  }
+
   def self.stub_consts_for(platform)
     STUBBED_CONSTS[platform].each do |const_name, const_value|
       stub_const_wrapper(const_name, const_value)
+    end
+    Puppet::Util::Platform.pretend_to_be(platform)
+    FEATURES[platform].each do |feature_name, feature_value|
+      Puppet.features.add(feature_name) { feature_value }
     end
   end
 
@@ -27,5 +42,16 @@ module RSpec::Puppet::Consts
 
   def self.restore_consts
     stub_consts_for(RSpec.configuration.platform)
+  end
+
+  def self.without_stubs
+    if Puppet::Util::Platform.pretending?
+      pretend_platform = Puppet::Util::Platform.pretend_platform
+      restore_consts
+    end
+
+    yield
+
+    stub_consts_for(pretend_platform) if pretend_platform
   end
 end

--- a/lib/rspec-puppet/consts.rb
+++ b/lib/rspec-puppet/consts.rb
@@ -51,7 +51,7 @@ module RSpec::Puppet::Consts
     end
 
     yield
-
+  ensure
     stub_consts_for(pretend_platform) if pretend_platform
   end
 end

--- a/lib/rspec-puppet/matchers/compile.rb
+++ b/lib/rspec-puppet/matchers/compile.rb
@@ -138,7 +138,6 @@ module RSpec::Puppet
       end
 
       def cycles_found?
-        Puppet::Type.suppress_provider
         cat = @catalogue.to_ral.relationship_graph
         cat.write_graph(:resources)
         if cat.respond_to? :find_cycles_in_graph
@@ -146,7 +145,6 @@ module RSpec::Puppet
         else
           find_cycles_legacy(cat)
         end
-        Puppet::Type.unsuppress_provider
 
         !@cycles.empty?
       end

--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -294,7 +294,6 @@ module RSpec::Puppet
           end
         end
 
-        Puppet::Type.suppress_provider
         # Add autorequires if any
         if type == :require and resource.resource_type.respond_to? :eachautorequire
           resource.resource_type.eachautorequire do |t, b|
@@ -307,7 +306,6 @@ module RSpec::Puppet
             end
           end
         end
-        Puppet::Type.unsuppress_provider
 
         results.flatten
       end

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -98,18 +98,6 @@ module Puppet
         old_set_default.bind(self).call(attr)
       end
     end
-
-    def self.suppress_provider?
-      @suppress_provider ||= false
-    end
-
-    def self.suppress_provider
-      @suppress_provider = true
-    end
-
-    def self.unsuppress_provider
-      @suppress_provider = false
-    end
   end
 
   module Parser::Files

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -160,6 +160,7 @@ module Puppet
           old_path_to_uri(*args)
         end
       end
+      module_function :path_to_uri
     end
 
     # Allow rspec-puppet to pretend to be different platforms.

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -154,7 +154,7 @@ module Puppet
 
       def windows?
         if RSpec::Puppet.rspec_puppet_example?
-          pretend_platform.nil? ? (actual_platform == :windows) : pretend_windows?
+          !pretending? ? (actual_platform == :windows) : pretend_windows?
         else
           old_windows?
         end
@@ -189,6 +189,27 @@ module Puppet
         @pretend_platform ||= nil
       end
       module_function :pretend_platform
+
+      def pretending?
+        !pretend_platform.nil?
+      end
+      module_function :pretending?
+    end
+
+    class Autoload
+      if singleton_class.respond_to?(:load_file)
+        singleton_class.send(:alias_method, :old_load_file, :load_file)
+
+        def self.load_file(*args)
+          if RSpec::Puppet.rspec_puppet_example?
+            RSpec::Puppet::Consts.without_stubs do
+              old_load_file(*args)
+            end
+          else
+            old_load_file(*args)
+          end
+        end
+      end
     end
   end
 

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -147,6 +147,21 @@ module Puppet
       module_function :get_env
     end
 
+    if respond_to?(:path_to_uri)
+      alias :old_path_to_uri :path_to_uri
+      module_function :old_path_to_uri
+
+      def path_to_uri(*args)
+        if RSpec::Puppet.rspec_puppet_example?
+          RSpec::Puppet::Consts.without_stubs do
+            old_path_to_uri(*args)
+          end
+        else
+          old_path_to_uri(*args)
+        end
+      end
+    end
+
     # Allow rspec-puppet to pretend to be different platforms.
     module Platform
       alias :old_windows? :windows?


### PR DESCRIPTION
Puppet6 modified basemodulepath so it's default value depends on the
env_windows_installdir fact. It also added a new setting,
vendormoduledir, that does the same. This commit stubs out the default
values for these settings as is done with modulepath. This behavior only
occurs when testing against Puppet6, so it's shouldn't affect older
puppet versions which don't define the vendormoduledir setting or use a
fact to determine the default basemodulepath.

See also PUP-8582.