### PR TITLE
(MODULES-7855) Fix test issues caused by new Puppet 6 validation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /vendor/
 .ruby-version
 /tmp/
-/spec/fixtures/modules/augeas_core
+/spec/fixtures/modules/augeas_core/
+/spec/fixtures/modules/stdlib/

--- a/Rakefile
+++ b/Rakefile
@@ -18,13 +18,17 @@ fixtures = {
   'stdlib'      => {
     :url         => 'https://github.com/puppetlabs/puppetlabs-stdlib',
     :requirement => Gem::Requirement.new('>= 0'),
+    :ref         => '4.2.0',
   },
 }
 
 namespace :test do
   RSpec::Core::RakeTask.new(:spec) do |t|
-    next unless t.respond_to?(:exclude_pattern)
-    t.exclude_pattern = 'spec/fixtures/**/*_spec.rb'
+    if t.respond_to?(:exclude_pattern)
+      t.exclude_pattern = 'spec/fixtures/**/*_spec.rb'
+    else
+      t.pattern = 'spec/{applications,classes,defines,functions,hosts,type_aliases,types,unit}/**/*_spec.rb'
+    end
   end
 
   task :setup do
@@ -37,6 +41,13 @@ namespace :test do
 
         system('git', 'clone', fixture[:url], name)
         fail unless $?.success?
+
+        if fixture.key?(:ref)
+          Dir.chdir(name) do
+            system('git', 'checkout', fixture[:ref])
+            fail unless $?.success?
+          end
+        end
       end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rake'
 require 'rspec/core/rake_task'
 require 'bundler/gem_tasks'
 require 'fileutils'
+require 'puppet'
 
 task :default => :test
 task :spec => :test
@@ -10,7 +11,14 @@ require 'rspec-puppet/tasks/release_test' unless RUBY_VERSION.start_with?('1')
 
 fixtures_dir = File.expand_path(File.join(__FILE__, '..', 'spec', 'fixtures', 'modules'))
 fixtures = {
-  'augeas_core' => 'https://github.com/puppetlabs/puppetlabs-augeas_core',
+  'augeas_core' => {
+    :url         => 'https://github.com/puppetlabs/puppetlabs-augeas_core',
+    :requirement => Gem::Requirement.new('>= 6.0.0'),
+  },
+  'stdlib'      => {
+    :url         => 'https://github.com/puppetlabs/puppetlabs-stdlib',
+    :requirement => Gem::Requirement.new('>= 0'),
+  },
 }
 
 namespace :test do
@@ -20,12 +28,14 @@ namespace :test do
   end
 
   task :setup do
-    next unless (ENV['PUPPET_GEM_VERSION'] || '').include?('#master')
+    puppet_version = Gem::Version.new(Puppet.version)
 
     Dir.chdir(fixtures_dir) do
-      fixtures.each do |name, repo|
+      fixtures.each do |name, fixture|
         next if File.directory?(name)
-        system('git', 'clone', repo, name)
+        next unless fixture[:requirement].satisfied_by?(puppet_version)
+
+        system('git', 'clone', fixture[:url], name)
         fail unless $?.success?
       end
     end

--- a/spec/classes/relationship__before_spec.rb
+++ b/spec/classes/relationship__before_spec.rb
@@ -16,8 +16,8 @@ describe 'relationships::before' do
   it { should contain_notify('bar').that_requires(['Notify[foo]']) }
   it { should contain_notify('baz').that_requires(['Notify[foo]','Notify[bar]']) }
 
-  it { should contain_class('relationship::before::pre').that_comes_before('Class[relationship::before::post]') }
-  it { should contain_class('relationship::before::post').that_requires('Class[relationship::before::pre]') }
+  it { should contain_class('relationships::before::pre').that_comes_before('Class[relationships::before::post]') }
+  it { should contain_class('relationships::before::post').that_requires('Class[relationships::before::pre]') }
 
   it { should contain_notify('pre').that_comes_before(['Notify[post]']) }
   it { should contain_notify('post').that_requires(['Notify[pre]']) }
@@ -38,6 +38,6 @@ describe 'relationships::before' do
   it { should_not contain_notify('bar').that_requires('Notify[unknown]') }
   it { should_not contain_notify('baz').that_requires('Notify[unknown]') }
 
-  it { should_not contain_class('relationship::before::pre').that_comes_before('Class[relationship::before::unknown]') }
-  it { should_not contain_class('relationship::before::post').that_requires('Class[relationship::before::unknown]') }
+  it { should_not contain_class('relationships::before::pre').that_comes_before('Class[relationships::before::unknown]') }
+  it { should_not contain_class('relationships::before::post').that_requires('Class[relationships::before::unknown]') }
 end

--- a/spec/fixtures/modules/relationships/manifests/before.pp
+++ b/spec/fixtures/modules/relationships/manifests/before.pp
@@ -15,19 +15,19 @@ class relationships::before {
   Notify['foo'] -> Notify['baz']
   Notify['baz'] <- Notify['bar']
 
-  class { '::relationship::before::pre': } ->
-  class { '::relationship::before::middle': } ->
-  class { '::relationship::before::post': }
+  class { '::relationships::before::pre': } ->
+  class { '::relationships::before::middle': } ->
+  class { '::relationships::before::post': }
 }
 
-class relationship::before::pre {
+class relationships::before::pre {
   notify { 'pre': }
 }
 
-class relationship::before::middle {
+class relationships::before::middle {
   notify { 'middle': }
 }
 
-class relationship::before::post {
+class relationships::before::post {
   notify { 'post': }
 }

--- a/spec/fixtures/modules/relationships/manifests/notify.pp
+++ b/spec/fixtures/modules/relationships/manifests/notify.pp
@@ -12,19 +12,19 @@ class relationships::notify {
 
   Notify['gronk'] <~ Notify['baz']
 
-  class { '::relationship::notify::pre': } ~>
-  class { '::relationship::notify::middle': } ~>
-  class { '::relationship::notify::post': }
+  class { '::relationships::notify::pre': } ~>
+  class { '::relationships::notify::middle': } ~>
+  class { '::relationships::notify::post': }
 }
 
-class relationship::notify::pre {
+class relationships::notify::pre {
   notify { 'pre': }
 }
 
-class relationship::notify::middle {
+class relationships::notify::middle {
   notify { 'middle': }
 }
 
-class relationship::notify::post {
+class relationships::notify::post {
   notify { 'post': }
 }

--- a/spec/fixtures/modules/sysctl/manifests/init.pp
+++ b/spec/fixtures/modules/sysctl/manifests/init.pp
@@ -17,19 +17,6 @@ define sysctl($value) {
   }
 }
 
-class boolean_test($bool) {
-  $real_bool = $bool ? {
-    true => false,
-    false => true,
-  }
-
-  if ($real_bool) {
-    notify {"bool testing":
-      message => "This will print when \$bool is false."
-    }
-  }
-}
-
 define sysctl::before($value) {
   Class['sysctl::common'] -> Sysctl::Before[$name]
 

--- a/spec/fixtures/modules/test/lib/puppet/parser/functions/ensure_packages.rb
+++ b/spec/fixtures/modules/test/lib/puppet/parser/functions/ensure_packages.rb
@@ -1,4 +1,0 @@
-Puppet::Parser::Functions.newfunction(:ensure_packages, :type => :statement) do |args|
-  Puppet::Parser::Functions.function(:create_resources)
-  function_create_resources(['Package', { args.first => {'ensure' => 'present'} }])
-end

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ensure_packages' do
-  before { subject.call(['facter']) }
+  before { subject.execute('facter') }
 
   it 'should create the resource in the catalogue' do
     expect(catalogue).to contain_package('facter').with_ensure('present')


### PR DESCRIPTION
Puppet 6 now validates expected module top level constructs and illegal definition locations.  This update fixes rspec-puppet test issues related to those new validation errors.