### PR TITLE
Reencode strings when matching to update line endings

### DIFF
--- a/lib/rspec-puppet/matchers/parameter_matcher.rb
+++ b/lib/rspec-puppet/matchers/parameter_matcher.rb
@@ -78,7 +78,7 @@ module RSpec::Puppet
       end
 
       def check_regexp(expected, actual)
-        !!(actual.to_s.match expected) == @should_match
+        !!(munge_line_endings(actual.to_s).match expected) == @should_match
       end
 
       # Ensure that two hashes have the same number of keys, and that for each
@@ -119,7 +119,17 @@ module RSpec::Puppet
       end
 
       def check_string(expected, actual)
-        (expected.to_s == actual.to_s) == @should_match
+        (expected.to_s == munge_line_endings(actual.to_s)) == @should_match
+      end
+
+      def munge_line_endings(value)
+        return value unless value.respond_to?(:encode)
+
+        if Puppet::Util::Platform.windows?
+          value.encode(:crlf_newline => true)
+        else
+          value.encode(:universal_newline => true)
+        end
       end
     end
   end


### PR DESCRIPTION
Puppet 6 has changed how it handles templates, the end result being that if running tests on Windows and pretending to be a non-Windows platform, we can now end up with CRLF line endings in rendered templates.

This PR changes the behaviour of the parameter matcher so that the value being matched is reencoded to have the line endings of the platform that rspec-puppet is pretending to be.