### PR TITLE
Fix Puppet::Util::Autoload.load_file to ignore stubbing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,10 @@ fixtures = {
     :requirement => Gem::Requirement.new('>= 0'),
     :ref         => '4.2.0',
   },
+  'registry'    => {
+    :url         => 'https://github.com/puppetlabs/puppetlabs-registry',
+    :requirement => Gem::Requirement.new('>= 0'),
+  },
 }
 
 namespace :test do

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -213,7 +213,7 @@ module Puppet
     end
 
     class Autoload
-      if singleton_class.respond_to?(:load_file)
+      if respond_to?(:load_file)
         singleton_class.send(:alias_method, :old_load_file, :load_file)
 
         def self.load_file(*args)

--- a/spec/classes/test_registry_spec.rb
+++ b/spec/classes/test_registry_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'test::registry', :if => Puppet.version.to_f >= 4.0 do
+  let(:facts) do
+    {
+      :operatingsystem => 'windows',
+    }
+  end
+
+  it { should compile.with_all_deps }
+end

--- a/spec/fixtures/modules/test/manifests/registry.pp
+++ b/spec/fixtures/modules/test/manifests/registry.pp
@@ -1,0 +1,6 @@
+class test::registry {
+  registry::value { 'puppetmaster':
+    key  => 'HKLM\Software\Vendor\PuppetLabs',
+    data =>  'puppet.puppetlabs.com',
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 if ENV['COVERAGE'] == 'yes'
+  require 'simplecov'
   require 'coveralls'
-  Coveralls.wear!
+
+  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+  SimpleCov.start do
+    add_filter(/^\/spec\//)
+  end
 end
 
 require 'rspec-puppet'


### PR DESCRIPTION
I mistakenly added `singleton_class` when checking if the class responds to
`load_file` (to support older versions of Puppet). This is obviously not
the correct method of determining if a class method has been defined and
as such did not work as intended.

This lead to the platform stubbing still being in place when `Kernel.load`
was being called, causing the problems reported by @cdenneen (where
a provider was evaluating `Puppet.features.microsoft_windows?` at load
time).