### PR TITLE
docs : add note about rspec-puppet-facts

### DIFF
--- a/docs/_includes/facts_inputs.md
+++ b/docs/_includes/facts_inputs.md
@@ -53,7 +53,12 @@ describe 'My::Class' do
 end
 {% endhighlight %}
 
-Note : It is also possible to populate facts with [rspec-puppet-facts](https://github.com/mcanevet/rspec-puppet-facts).
+<div class="callout-block callout-info">
+<div class="icon-holder"><i class="fa fa-info-circle"></i></div>
+<div class="content">
+A common pattern is to use <a href="https://github.com/mcanevet/rspec-puppet-facts">rspec-puppet-facts</a> to automatically populate the facts for a specified operating system. Please read the <a href="https://github.com/mcanevet/rspec-puppet-facts/blob/master/README.md">rspec-puppet-facts documentation</a> for more information.
+</div>
+</div>
 
 ### Specifying trusted facts
 

--- a/docs/_includes/facts_inputs.md
+++ b/docs/_includes/facts_inputs.md
@@ -53,6 +53,8 @@ describe 'My::Class' do
 end
 {% endhighlight %}
 
+Note : It is also possible to populate facts with [rspec-puppet-facts](https://github.com/mcanevet/rspec-puppet-facts).
+
 ### Specifying trusted facts
 
 When testing with Puppet >= 4.3, the trusted facts hash will have the standard


### PR DESCRIPTION
I know it is `rspec-puppet` doc but it should be interesting to get a note about `rspec-puppet-facts` in facts testing section.