### PR TITLE
Allow customizing module-layer Hiera configuration

### DIFF
--- a/lib/rspec-puppet.rb
+++ b/lib/rspec-puppet.rb
@@ -54,6 +54,10 @@ RSpec.configure do |c|
   c.add_setting :platform, :default => Puppet::Util::Platform.actual_platform
   c.add_setting :vendormoduledir, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
   c.add_setting :basemodulepath, :default => Puppet::Util::Platform.actually_windows? ? 'c:/nul/' : '/dev/null'
+  c.add_setting :disable_module_hiera, :default => false
+  c.add_setting :fixture_hiera_configs, :default => {}
+  c.add_setting :use_fixture_spec_hiera, :default => false
+  c.add_setting :fallback_to_default_hiera, :default => true
 
   c.instance_eval do
     def trusted_server_facts

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -258,6 +258,40 @@ module Puppet
       end
     end
   end
+
+  if Puppet::Util::Package.versioncmp(Puppet.version, '4.9.0') >= 0
+    class Module
+      old_hiera_conf_file = instance_method(:hiera_conf_file)
+      define_method(:hiera_conf_file) do
+        if RSpec::Puppet.rspec_puppet_example?
+          if RSpec.configuration.disable_module_hiera
+            return nil
+          elsif RSpec.configuration.fixture_hiera_configs.key?(name)
+            config = RSpec.configuration.fixture_hiera_configs[name]
+            config = File.absolute_path(config, path) unless config.nil?
+            return config
+          elsif RSpec.configuration.use_fixture_spec_hiera
+            config = RSpec::Puppet.current_example.fixture_spec_hiera_conf(self)
+            return config unless config.nil? && RSpec.configuration.fallback_to_default_hiera
+          end
+        end
+        old_hiera_conf_file.bind(self).call
+      end
+    end
+
+    class Pops::Lookup::ModuleDataProvider
+      old_configuration_path = instance_method(:configuration_path)
+      define_method(:configuration_path) do |lookup_invocation|
+        if RSpec::Puppet.rspec_puppet_example?
+          env = lookup_invocation.scope.environment
+          mod = env.module(module_name)
+          raise Puppet::DataBinding::LookupError, _("Environment '%{env}', cannot find module '%{module_name}'") % { :env => env.name, :module_name => module_name } unless mod
+          return Pathname.new(mod.hiera_conf_file)
+        end
+        old_configuration_path.bind(self).call(lookup_invocation)
+      end
+    end
+  end
 end
 
 class Pathname

--- a/spec/classes/hiera_integration_spec.rb
+++ b/spec/classes/hiera_integration_spec.rb
@@ -12,3 +12,156 @@ describe 'test::hiera', :if => Puppet.version.to_f >= 3.0 do
   end
 end
 
+describe 'hiera_test', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.9.0') >= 0 do
+  before(:each) do
+    RSpec.configuration.disable_module_hiera = false
+    RSpec.configuration.use_fixture_spec_hiera = false
+    RSpec.configuration.fixture_hiera_configs = {}
+    RSpec.configuration.fallback_to_default_hiera = true
+  end
+
+  context 'without :hiera_config set' do
+    context 'with module eyaml hiera data enabled' do
+      it { should raise_error(Puppet::PreformattedError, %r{hiera_eyaml}) }
+    end
+
+    context 'with module eyaml hiera data disabled' do
+      before(:each) { RSpec.configuration.disable_module_hiera = true }
+
+      it { should raise_error(Puppet::ParseError) }
+    end
+
+    context 'with relative fixture hiera config path' do
+      before(:each) { RSpec.configuration.fixture_hiera_configs = {'hiera_test' => 'spec/module_hiera.yaml'} }
+
+      it { should contain_notify('module') }
+    end
+
+    context 'with absolute fixture hiera config path' do
+      before(:each) do
+        RSpec.configuration.fixture_hiera_configs = {
+            'hiera_test' => File.join(__FILE__, '../../fixtures/modules/hiera_test/spec/module_hiera.yaml')
+        }
+      end
+
+      it { should contain_notify('module') }
+    end
+
+    context 'with invalid fixture hiera config path' do
+      before(:each) { RSpec.configuration.fixture_hiera_configs = {'hiera_test' => 'non_existent.yaml'} }
+
+      it { should raise_error(Puppet::ParseError) }
+    end
+
+    context 'with :use_fixture_spec_hiera set' do
+      before(:each) { RSpec.configuration.use_fixture_spec_hiera = true }
+
+      it { should contain_notify('spec') }
+    end
+  end
+
+  context 'with :hiera_config set' do
+    let(:hiera_config) { 'spec/fixtures/hiera.yaml' }
+
+    context 'with module eyaml hiera data enabled' do
+      it { should raise_error(Puppet::PreformattedError, %r{hiera_eyaml}) }
+    end
+
+    context 'with module eyaml hiera data disabled' do
+      before(:each) { RSpec.configuration.disable_module_hiera = true }
+
+      it { should contain_notify('global') }
+    end
+
+    context 'with relative fixture hiera config path' do
+      before(:each) { RSpec.configuration.fixture_hiera_configs = {'hiera_test' => 'spec/module_hiera.yaml'} }
+
+      it { should contain_notify('global') }
+    end
+
+    context 'with absolute fixture hiera config path' do
+      before(:each) do
+        RSpec.configuration.fixture_hiera_configs = {
+            'hiera_test' => File.join(__FILE__, '../../fixtures/modules/hiera_test/spec/module_hiera.yaml')
+        }
+      end
+
+      it { should contain_notify('global') }
+    end
+
+    context 'with invalid fixture hiera config path' do
+      before(:each) { RSpec.configuration.fixture_hiera_configs = {'hiera_test' => 'non_existent.yaml'} }
+
+      it { should contain_notify('global') }
+    end
+
+    context 'with :use_fixture_spec_hiera set' do
+      before(:each) { RSpec.configuration.use_fixture_spec_hiera = true }
+
+      it { should contain_notify('global') }
+    end
+  end
+end
+
+describe 'hiera_test2', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.9.0') >= 0 do
+  before(:each) do
+    RSpec.configuration.disable_module_hiera = false
+    RSpec.configuration.use_fixture_spec_hiera = false
+    RSpec.configuration.fixture_hiera_configs = {}
+    RSpec.configuration.fallback_to_default_hiera = true
+  end
+
+  context 'without :hiera_config set' do
+    context 'with module-layer hiera enabled' do
+      it { should contain_notify('module') }
+    end
+
+    context 'with module-layer hiera disabled' do
+      before(:each) { RSpec.configuration.disable_module_hiera = true }
+
+      it { should raise_error(Puppet::ParseError) }
+    end
+
+    context 'with :use_fixture_spec_hiera set' do
+      before(:each) { RSpec.configuration.use_fixture_spec_hiera = true }
+
+      context 'with missing spec hiera.yaml and hiera fallback enabled' do
+        it { should contain_notify('module') }
+      end
+
+      context 'with missing spec hiera.yaml and hiera fallback disabled' do
+        before(:each) { RSpec.configuration.fallback_to_default_hiera = false }
+
+        it { should raise_error(Puppet::ParseError) }
+      end
+    end
+  end
+
+  context 'with :hiera_config set' do
+    let(:hiera_config) { 'spec/fixtures/hiera.yaml' }
+
+    context 'with module-layer hiera enabled' do
+      it { should contain_notify('global') }
+    end
+
+    context 'with module-layer hiera disabled' do
+      before(:each) { RSpec.configuration.disable_module_hiera = true }
+
+      it { should contain_notify('global') }
+    end
+
+    context 'with :use_fixture_spec_hiera set' do
+      before(:each) { RSpec.configuration.use_fixture_spec_hiera = true }
+
+      context 'with missing spec hiera.yaml and hiera fallback enabled' do
+        it { should contain_notify('global') }
+      end
+
+      context 'with missing spec hiera.yaml and hiera fallback disabled' do
+        before(:each) { RSpec.configuration.fallback_to_default_hiera = false }
+
+        it { should contain_notify('global') }
+      end
+    end
+  end
+end

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,2 +1,4 @@
 ---
 data: foo
+hiera_test::test_param: global
+hiera_test2::test_param: global

--- a/spec/fixtures/modules/hiera_test/data/common.yaml
+++ b/spec/fixtures/modules/hiera_test/data/common.yaml
@@ -1,0 +1,2 @@
+---
+hiera_test::test_param: module

--- a/spec/fixtures/modules/hiera_test/hiera.yaml
+++ b/spec/fixtures/modules/hiera_test/hiera.yaml
@@ -1,0 +1,11 @@
+---
+version: 5
+defaults:
+  datadir: data
+  lookup_key: eyaml_lookup_key
+hierarchy:
+  - name: 'Defaults'
+    glob: '**.yaml'
+    options:
+      pkcs7_private_key: /fakekey
+      pkcs7_public_key: /fakepubkey

--- a/spec/fixtures/modules/hiera_test/manifests/init.pp
+++ b/spec/fixtures/modules/hiera_test/manifests/init.pp
@@ -1,0 +1,5 @@
+class hiera_test (
+  $test_param,
+) {
+  notify { $test_param: }
+}

--- a/spec/fixtures/modules/hiera_test/spec/data/common.yaml
+++ b/spec/fixtures/modules/hiera_test/spec/data/common.yaml
@@ -1,0 +1,2 @@
+---
+hiera_test::test_param: spec

--- a/spec/fixtures/modules/hiera_test/spec/hiera.yaml
+++ b/spec/fixtures/modules/hiera_test/spec/hiera.yaml
@@ -1,0 +1,8 @@
+---
+version: 5
+defaults:
+  data_hash: yaml_data
+  datadir: data
+hierarchy:
+  - name: Common
+    path: common.yaml

--- a/spec/fixtures/modules/hiera_test/spec/module_hiera.yaml
+++ b/spec/fixtures/modules/hiera_test/spec/module_hiera.yaml
@@ -1,0 +1,8 @@
+---
+version: 5
+defaults:
+  data_hash: yaml_data
+  datadir: ../data
+hierarchy:
+  - name: Common
+    path: common.yaml

--- a/spec/fixtures/modules/hiera_test2/data/common.yaml
+++ b/spec/fixtures/modules/hiera_test2/data/common.yaml
@@ -1,0 +1,2 @@
+---
+hiera_test2::test_param: module

--- a/spec/fixtures/modules/hiera_test2/hiera.yaml
+++ b/spec/fixtures/modules/hiera_test2/hiera.yaml
@@ -1,0 +1,8 @@
+---
+version: 5
+defaults:
+  data_hash: yaml_data
+  datadir: data
+hierarchy:
+  - name: 'Defaults'
+    glob: '**.yaml'

--- a/spec/fixtures/modules/hiera_test2/manifests/init.pp
+++ b/spec/fixtures/modules/hiera_test2/manifests/init.pp
@@ -1,0 +1,5 @@
+class hiera_test2 (
+  $test_param,
+) {
+  notify { $test_param: }
+}


### PR DESCRIPTION
This adds four new RSpec configuration parameters to modify the behavior of module-layer Hiera data.

- disable_module_hiera
  - Enabling this will prevent Puppet from using module-layer Hiera data entirely. This includes the module being tested as well as any fixture modules. The end effect is that only Hiera data from the global :hiera_config parameter will be used.
- use_fixture_spec_hiera
  - Enabling this will prevent Puppet from using the module-layer Hiera config file and instead search the module spec folder for a file named hiera.yaml.
- fallback_to_default_hiera
  - Controls whether or not to fall back to the default hiera.yaml file for the module layer if use_fixture_spec_hiera is enabled and no spec hiera.yaml file is found. Defaults to true.
- fixture_hiera_configs
  - A hash of module names and their respective module-layer Hiera config file paths. This can be used to override the path to the module-layer hiera.yaml.

The original impetus for creating these settings was to solve errors generated from modules that had eyaml enabled in their hiera config files. Even with :hiera_config set appropriately, Puppet would still try to load hiera data from the module layer. See #626.

If these settings seem useful for merging, I would be glad to update any appropriate documentation.