### PR TITLE
allow users to disable app_managment for puppet4

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -355,7 +355,7 @@ module RSpec::Puppet
 
       # Enable app_management by default for Puppet versions that support it
       if Puppet::Util::Package.versioncmp(Puppet.version, '4.3.0') >= 0 && Puppet.version.to_i < 5
-        Puppet[:app_management] = true
+        Puppet[:app_management] = ENV.include?('PUPPET_NOAPP_MANAGMENT') ? false : true
       end
 
       adapter.modulepath.map do |d|


### PR DESCRIPTION
I ran into a bug today which was triggered because app_management was enabled.  I couldn't see a way to disable it  `Puppet[:app_management]  = true` in my spec_helper didn't help.  This adds an environment variable to allow uses to disable app_management 

edit: below is output of errors we get with with `app_managment: true`
 * https://integration.wikimedia.org/ci/job/operations-puppet-tests-stretch-docker/16591/console

this is caused when i apply the following change i.e. removing a monkey patch to disable app_managment
 * https://gerrit.wikimedia.org/r/c/operations/puppet/+/521939

The error we had is caused because we use `$site` as a global variable and when `app_managment` is enabled site becomes a reserved variable name.  As we don't use `app_managment` its not an issue for us 

also the build link should stick around but let me know if does go dead and i can provide a fresh one