### PR TITLE
Support directories for the manifest setting

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -129,13 +129,18 @@ module RSpec::Puppet
     end
 
     def site_pp_str
-      site_pp_str = ''
-      filepath = adapter.manifest
+      return '' unless (path = adapter.manifest)
 
-      if (!filepath.nil?) && File.file?(filepath)
-        site_pp_str = File.open(filepath).read
+      if File.file?(path)
+        File.read(path)
+      elsif File.directory?(path)
+        # Read and concatenate all .pp files.
+        Dir[File.join(path, '*.pp')].sort.map do |f|
+          File.read(f)
+        end.join("\n")
+      else
+        ''
       end
-      site_pp_str
     end
 
     def test_manifest(type, opts = {})


### PR DESCRIPTION
Rspec-puppet currently doesn't support loading a directory as a manifest
like the `manifest` setting in Puppet does.

When testing environments that have a directory as a manifest you have
to resort to manually loading all the files in the directory in a
:pre_condition which leads to a clumsy experience (especially when you
need :pre_condition for other reasons).

This commit should solve this by alphabetically loading all .pp files if
manifest is a directory.