### PR TITLE
Revert "Support directories for the manifest setting"

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -129,18 +129,13 @@ module RSpec::Puppet
     end
 
     def site_pp_str
-      return '' unless (path = adapter.manifest)
+      site_pp_str = ''
+      filepath = adapter.manifest
 
-      if File.file?(path)
-        File.read(path)
-      elsif File.directory?(path)
-        # Read and concatenate all .pp files.
-        Dir[File.join(path, '*.pp')].sort.map do |f|
-          File.read(f)
-        end.join("\n")
-      else
-        ''
+      if (!filepath.nil?) && File.file?(filepath)
+        site_pp_str = File.open(filepath).read
       end
+      site_pp_str
     end
 
     def test_manifest(type, opts = {})


### PR DESCRIPTION
Reverts rodjek/rspec-puppet#748

This is a breaking change.  For our modules we currently place various .pp files in `spec/fixtures/manifests`.  Many of those .pp files conflict with existing pre_condition statements we have so after this change when in all of our tests failed with duplicate declaration errors.  