### PR TITLE
Remove the temporary rspec-expectations pin

### DIFF
--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG.md', 'LICENSE.md', 'README.md', 'lib/**/*', 'bin/**/*']
 
   s.add_dependency 'rspec'
-  s.add_dependency 'rspec-expectations', '< 3.8.5'
 
   s.authors = ['Tim Sharpe']
   s.email = 'tim@sharpe.id.au'


### PR DESCRIPTION
With #767, this temporary pin can be removed.