### PR TITLE
(#771) Set a default dummy ipaddress6 fact

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -226,10 +226,11 @@ module RSpec::Puppet
       }
 
       node_facts = {
-        'hostname'      => node.split('.').first,
-        'fqdn'          => node,
-        'domain'        => node.split('.', 2).last,
-        'clientcert'    => node,
+        'hostname'   => node.split('.').first,
+        'fqdn'       => node,
+        'domain'     => node.split('.', 2).last,
+        'clientcert' => node,
+        'ipaddress6' => 'FE80:0000:0000:0000:AAAA:AAAA:AAAA',
       }
 
       networking_facts = {


### PR DESCRIPTION
Puppet 6.9.0 started setting a `serverip6` server fact which is set
using the value of the `ipaddress6` fact. If the fact set(s) provided by
FacterDB don't have an `ipaddress6` fact set, then the normal Facter
fact will be resolved, which can result in Ruby trying to load Windows
only gems on Linux.

Fixes #771