### PR TITLE
monkey-patch match_manifests to not load init.pp when not necessary

### DIFF
--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -297,12 +297,12 @@ end
 # "mod::foo", this causes duplicate declaration for "mod".
 # This monkey patch only loads "init.pp" if "foo.pp" does not exist.
 class Puppet::Module
-  if instance_methods.include?(:match_manifests)
+  if [:match_manifests, 'match_manifests'].any? { |r| instance_methods.include?(r) }
     old_match_manifests = instance_method(:match_manifests)
 
     define_method(:match_manifests) do |rest|
       result = old_match_manifests.bind(self).call(rest)
-      if result.length > 1 && result[0] =~ %r{/init.pp$}
+      if result.length > 1 && File.basename(result[0]) == 'init.pp'
         result.shift
       end
       result

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -292,6 +292,24 @@ class Pathname
   end
 end
 
+# Puppet loads init.pp, then foo.pp, to find class "mod::foo".  If
+# class "mod" has been mocked using pre_condition when testing
+# "mod::foo", this causes duplicate declaration for "mod".
+# This monkey patch only loads "init.pp" if "foo.pp" does not exist.
+class Puppet::Module
+  if instance_methods.include?(:match_manifests)
+    old_match_manifests = instance_method(:match_manifests)
+
+    define_method(:match_manifests) do |rest|
+      result = old_match_manifests.bind(self).call(rest)
+      if result.length > 1 && result[0] =~ %r{/init.pp$}
+        result.shift
+      end
+      result
+    end
+  end
+end
+
 # Prevent the File type from munging paths (which uses File.expand_path to
 # normalise paths, which does very bad things to *nix paths on Windows.
 file_path_munge = Puppet::Type.type(:file).paramclass(:path).instance_method(:unsafe_munge)

--- a/spec/unit/monkey_patches_spec.rb
+++ b/spec/unit/monkey_patches_spec.rb
@@ -130,19 +130,32 @@ describe 'Pathname#rspec_puppet_basename' do
 end
 
 describe "Puppet::Module#match_manifests" do
-  subject {
-    Puppet::Module.new('escape',
-                       File.join(RSpec.configuration.module_path, 'escape'),
-                       'production')
-  }
+  subject do
+    if Puppet::Module.instance_method(:initialize).arity == -2
+      Puppet::Module.new(
+        'escape',
+        :path        => File.join(RSpec.configuration.module_path, 'escape'),
+        :environment => 'production'
+      )
+    else
+      Puppet::Module.new(
+        'escape',
+        File.join(RSpec.configuration.module_path, 'escape'),
+        'production'
+      )
+    end
+  end
+
   it 'returns init.pp for top level class' do
     expect(subject.match_manifests(nil).length).to eq(1)
     expect(subject.match_manifests(nil)[0]).to match(/init\.pp$/)
   end
+
   it 'returns init.pp for escape::unknown' do
     expect(subject.match_manifests('unknown').length).to eq(1)
     expect(subject.match_manifests('unknown')[0]).to match(/init\.pp$/)
   end
+
   it 'returns just def.pp for escape::def' do
     expect(subject.match_manifests('def').length).to eq(1)
     expect(subject.match_manifests('def')[0]).to match(/def\.pp$/)

--- a/spec/unit/monkey_patches_spec.rb
+++ b/spec/unit/monkey_patches_spec.rb
@@ -128,3 +128,24 @@ describe 'Pathname#rspec_puppet_basename' do
     end
   end
 end
+
+describe "Puppet::Module#match_manifests" do
+  subject {
+    Puppet::Module.new('escape',
+                       File.join(RSpec.configuration.module_path, 'escape'),
+                       'production')
+  }
+  it 'returns init.pp for top level class' do
+    expect(subject.match_manifests(nil).length).to eq(1)
+    expect(subject.match_manifests(nil)[0]).to match(/init\.pp$/)
+  end
+  it 'returns init.pp for escape::unknown' do
+    expect(subject.match_manifests('unknown').length).to eq(1)
+    expect(subject.match_manifests('unknown')[0]).to match(/init\.pp$/)
+  end
+  it 'returns just def.pp for escape::def' do
+    expect(subject.match_manifests('def').length).to eq(1)
+    expect(subject.match_manifests('def')[0]).to match(/def\.pp$/)
+  end
+end
+


### PR DESCRIPTION
When loading a class, Puppet::Module::match_manifests is used to list
candidate filenames.  To maintain backwards compatibility, it will return
init.pp for the module first in the list, so that a class may be declared
outside autoload namespace (Puppet bug #4220).

Normally, this does not cause any problems, but if pre_condition is used
to make a simplified version of the top class in your module, Puppet will
complain about a duplicate declaration.

```ruby
  describe "baseconfig::logging" do
    let(:pre_condition) { [
     'class baseconfig($enable_filebeat=false) { }',
     'include baseconfig',
    ] }
```

This results in an error like this:

  error during compilation: Class 'baseconfig' is already defined (line: 2); cannot
  redefine (file: /home/kjetilho/src/baseconfig/spec/fixtures/modules/baseconfig/manifests/init.pp,
  line: 6) on node ranger.ms.redpill-linpro.com

The patch changes the logic so that it removes init.pp from the beginning
of the list if there are other files in the list.  This will break code
which puts the class foo::bar in foo/manifests/init.pp *and* has a file
foo/manifests/bar.pp in the project, but I believe such code thoroughly
deserves to break.