### PR TITLE
Switch to non-inplace gsub in escape_special_chars

### DIFF
--- a/lib/rspec-puppet/support.rb
+++ b/lib/rspec-puppet/support.rb
@@ -441,8 +441,7 @@ module RSpec::Puppet
     end
 
     def escape_special_chars(string)
-      string.gsub!(/\$/, "\\$")
-      string
+      string.gsub(/\$/, "\\$")
     end
 
     def rspec_compatibility


### PR DESCRIPTION
In ruby2.7 the input to escape_special_chars() might be frozen. Solves #789