### PR TITLE
Do not raise failure if nothing is tested

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -155,7 +155,7 @@ module RSpec::Puppet
       if coverage_desired.is_a?(Numeric) && coverage_desired.to_f <= 100.00 && coverage_desired.to_f >= 0.0
         coverage_test = RSpec.describe("Code coverage")
         coverage_results = coverage_test.example("must cover at least #{coverage_desired}% of resources") do
-          expect( coverage_actual.to_f ).to be >= coverage_desired.to_f
+          expect( coverage_actual.to_f ).to be >= coverage_desired.to_f unless report[:total].zero?
         end
         coverage_test.run(RSpec.configuration.reporter)
 


### PR DESCRIPTION
`RSpec::Puppet::Coverage.report!(percents)` raises test failure if the total amount of tested puppet resources is 0. So either it annoys during ruby code development or should be mitigated with the following snippet in spec_helper.rb

```ruby
RSpec.configure do |c|
  c.after(:suite) do
    RSpec::Puppet::Coverage.report!(94) unless RSpec::Puppet::Coverage.results[:total].zero?
  end
end
```

This PR implement checking of coverage only on total checked puppet resources greater than 0.