### PR TITLE
796 Fix issues with `puppet` gem removal of `default_env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+ * Fix issues with puppet gem removal of `default_env` #796
+
 ## [2.7.8]
 
 ### Fixed

--- a/lib/rspec-puppet/monkey_patches.rb
+++ b/lib/rspec-puppet/monkey_patches.rb
@@ -132,6 +132,16 @@ module Puppet
   end
 
   module Util
+    # Fix for removal of default_env function
+    # Bug: https://github.com/rodjek/rspec-puppet/issues/796
+    # Upstream: https://github.com/puppetlabs/puppet/commit/94df3c1a3992d89b2d7d5db8a70373c135bdd86b
+    if !respond_to?(:default_env)
+      def default_env()
+        DEFAULT_ENV
+      end
+      module_function :default_env
+    end
+
     if respond_to?(:get_env)
       alias :old_get_env :get_env
       module_function :old_get_env


### PR DESCRIPTION
Since this is now changed to `DEFAULT_ENV`, we now create the old
function alias to retain functionality.

Bug: https://github.com/rodjek/rspec-puppet/issues/796
Upstream: https://github.com/puppetlabs/puppet/blob/94df3c1a3992d89b2d7d5db8a70373c135bdd86b/lib/puppet/util.rb