### PR TITLE
Add 2.7.10 release to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.7.9]
+## [2.7.10]
+
 ### Fixed
  * Fix issues with removal of `default_env` method in Puppet 6.17.0.
+
+## [2.7.9]
+
+This release had unintended breaking changes and was withdrawn.
 
 ## [2.7.8]
 

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -4,13 +4,17 @@ title: Change Log
 icon: fa fa-history
 ---
 
-## 2.7.9
+## 2.7.10
 
-<a href="https://github.com/rodjek/rspec-puppet/compare/v2.7.8...v2.7.9"
+<a href="https://github.com/rodjek/rspec-puppet/compare/v2.7.8...v2.7.10"
 class="btn btn-primary btn-inline pull-right">View Diff</a>
 
 ### Fixed
  * Fix issues with removal of `default_env` method in Puppet 6.17.0.
+
+## 2.7.9
+
+This release had unintended breaking changes and was withdrawn.
 
 ## 2.7.8
 

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rspec-puppet'
-  s.version = '2.7.10'
+  s.version = '2.8.0.pre'
   s.homepage = 'https://github.com/rodjek/rspec-puppet/'
   s.summary = 'RSpec tests for your Puppet manifests'
   s.description = 'RSpec tests for your Puppet manifests'

--- a/rspec-puppet.gemspec
+++ b/rspec-puppet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rspec-puppet'
-  s.version = '2.7.9'
+  s.version = '2.7.10'
   s.homepage = 'https://github.com/rodjek/rspec-puppet/'
   s.summary = 'RSpec tests for your Puppet manifests'
   s.description = 'RSpec tests for your Puppet manifests'


### PR DESCRIPTION
Adds changelog entries for the `2.7.10` release that was made from the `2.7.x` branch. Also bumps the current version to `2.8.0.pre`