### PR TITLE
coverage.rb: Fix handling of 0 total resources

### DIFF
--- a/lib/rspec-puppet/coverage.rb
+++ b/lib/rspec-puppet/coverage.rb
@@ -187,7 +187,12 @@ module RSpec::Puppet
       report[:total] = @collection.size
       report[:touched] = @collection.count { |_, resource| resource.touched? }
       report[:untouched] = report[:total] - report[:touched]
-      report[:coverage] = "%5.2f" % ((report[:touched].to_f / report[:total].to_f) * 100)
+      if report[:total].to_f > 0
+        report[:coverage] = "%5.2f" % ((report[:touched].to_f / report[:total].to_f) * 100)
+      else
+        # if there are no resources, all of these were touched
+        report[:coverage] = "  100.00%"
+      end
 
       report[:resources] = Hash[*@collection.map do |name, wrapper|
         [name, wrapper.to_hash]


### PR DESCRIPTION
If there are 0 total resources, a percentage of NaN was generated as
division by zero was not prevented. This checks if the divisor is zero
and sets the percentage to 100 if so.