### PR TITLE
Adjust raise_error to allow rspec-expectation's 3.10.0 changes

### DIFF
--- a/lib/rspec-puppet/matchers/raise_error.rb
+++ b/lib/rspec-puppet/matchers/raise_error.rb
@@ -16,8 +16,8 @@ module RSpec::Puppet
       end
     end
 
-    def raise_error(*args, &block)
-      RaiseError.new(*args, &block)
+    def raise_error(error=defined?(RSpec::Matchers::BuiltIn::RaiseError::UndefinedValue) ? RSpec::Matchers::BuiltIn::RaiseError::UndefinedValue : nil, message=nil, &block)
+      RaiseError.new(error, message, &block)
     end
   end
 end


### PR DESCRIPTION
In 3.10.0 rspec-expectations changed the `RaiseError` constructor to
require the first two arguments. While technically a breaking change,
this was alleviated by a fix in their DSL at https://github.com/rspec/rspec-expectations/commit/06ca736c5a1e9f5974e9c2d88c8992e7160cd618#diff-a62835906c442ece0b40d01ff6da519153cd4f671568900a1068370f30892cfcR770

This change adjusts rspec-puppet's `raise_error` to do the same.