### PR TITLE
Handle all auto*, not just autorequire

### DIFF
--- a/lib/rspec-puppet/matchers/create_generic.rb
+++ b/lib/rspec-puppet/matchers/create_generic.rb
@@ -307,14 +307,17 @@ module RSpec::Puppet
           end
         end
 
-        # Add autorequires if any
-        if type == :require and resource.resource_type.respond_to? :eachautorequire
-          resource.resource_type.eachautorequire do |t, b|
-            Array(resource.to_ral.instance_eval(&b)).each do |dep|
-              res = "#{t.to_s.capitalize}[#{dep}]"
-              if r = relationship_refs(res, type, visited)
-                results << res
-                results << r
+        # Add auto* (autorequire etc) if any
+        if [:before, :notify, :require, :subscribe].include?(type)
+          func = "eachauto#{type}".to_sym
+          if resource.resource_type.respond_to?(func)
+            resource.resource_type.send(func) do |t, b|
+              Array(resource.to_ral.instance_eval(&b)).each do |dep|
+                res = "#{t.to_s.capitalize}[#{dep}]"
+                if r = relationship_refs(res, type, visited)
+                  results << res
+                  results << r
+                end
               end
             end
           end

--- a/lib/rspec-puppet/matchers/type_matchers.rb
+++ b/lib/rspec-puppet/matchers/type_matchers.rb
@@ -52,9 +52,6 @@ module RSpec::Puppet
         self
       end
 
-      #def with_autorequires(autorequires))
-      #end
-
       #
       # this is the method that drives all of the validation
       #

--- a/spec/classes/relationships__type_with_auto.rb
+++ b/spec/classes/relationships__type_with_auto.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'relationships::type_with_auto', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.0.0') >= 0 do
+  it { is_expected.to compile.with_all_deps }
+  it do
+    is_expected.to contain_type_with_all_auto('/tmp')
+      .that_comes_before('File[/tmp/before]')
+      .that_notifies('File[/tmp/notify]')
+      .that_requires('File[/tmp/require]')
+      .that_subscribes_to('File[/tmp/subscribe]')
+  end
+
+  it { is_expected.to contain_file('/tmp/before').that_requires('Type_with_all_auto[/tmp]') }
+  it { is_expected.to contain_file('/tmp/notify').that_subscribes_to('Type_with_all_auto[/tmp]') }
+  it { is_expected.to contain_file('/tmp/require').that_comes_before('Type_with_all_auto[/tmp]') }
+  it { is_expected.to contain_file('/tmp/subscribe').that_notifies('Type_with_all_auto[/tmp]') }
+end

--- a/spec/fixtures/modules/relationships/lib/puppet/type/type_with_all_auto.rb
+++ b/spec/fixtures/modules/relationships/lib/puppet/type/type_with_all_auto.rb
@@ -1,0 +1,8 @@
+Puppet::Type.newtype(:type_with_all_auto) do
+  ensurable
+  newparam(:name, :namevar => true)
+  autobefore(:file) { [File.join(self[:name], 'before')] }
+  autonotify(:file) { [File.join(self[:name], 'notify')] }
+  autorequire(:file) { [File.join(self[:name], 'require')] }
+  autosubscribe(:file) { [File.join(self[:name], 'subscribe')] }
+end

--- a/spec/fixtures/modules/relationships/manifests/type_with_auto.pp
+++ b/spec/fixtures/modules/relationships/manifests/type_with_auto.pp
@@ -1,0 +1,9 @@
+# This class is here to test type_with_all_auto which has alll auto* relations
+class relationships::type_with_auto {
+  type_with_all_auto { '/tmp':
+  }
+
+  file { ['/tmp/before', '/tmp/notify', '/tmp/require', '/tmp/subscribe']:
+    ensure => file,
+  }
+}


### PR DESCRIPTION
Since [Puppet 4.0.0](https://github.com/puppetlabs/puppet/commit/b864bfbcd0792cb1cee0cb8a537f586dedbb04e6) types can specify autobefore, autonotify, autorequire and autosuscribe. This allows testing these relations.