### PR TITLE
Added support for regexp arguments to Sensitive

### DIFF
--- a/lib/rspec-puppet/sensitive.rb
+++ b/lib/rspec-puppet/sensitive.rb
@@ -29,7 +29,11 @@ module RSpec::Puppet
       # @param other [#unwrap, Object] value to compare to
       def == other
         if other.respond_to? :unwrap
-          return unwrap == other.unwrap
+          if unwrap.kind_of?(Regexp)
+            return unwrap =~ other.unwrap
+          else
+            return unwrap == other.unwrap
+          end
         else
           super
         end

--- a/spec/classes/test_sensitive_spec.rb
+++ b/spec/classes/test_sensitive_spec.rb
@@ -2,4 +2,5 @@ require 'spec_helper'
 
 describe 'test::sensitive', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.6.0') >= 0 do
   it { is_expected.to contain_class('test::sensitive::user').with_password(sensitive('myPassword')) }
+  it { is_expected.to contain_class('test::sensitive::user').with_password(sensitive(%r{Pass})) }
 end


### PR DESCRIPTION
Sometimes we have big configuration files created from templates. Sometimes we test its contents in our unit tests.
When file content is just string (`content => template('blah/blah.erb')`), it's easy to test only one line with `it { should contain_file('blah').with_content(%r{regexp for interesting line}) }`.
However, if we change file content to Sensitive (`content => Sensitive(template('blah/blah.erb'))`), it becomes impossible to test contents without specifying whole contents - you can't test it with `it { should contain_file('blah').with_content(sensitive(%r{regexp for interesting line})) }`.
Well, with these changes - you can.