### PR TITLE
Set up loaders so that 4.x functions resolve properly

### DIFF
--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -140,7 +140,7 @@ module RSpec::Puppet
           {
             :environments => loader,
             :current_environment => env,
-            :loaders => Puppet::Pops::Loaders.new(env),
+            :loaders => (Puppet::Pops::Loaders.new(env) if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')),
           },
           "Setup rspec-puppet environments"
         )

--- a/lib/rspec-puppet/adapters.rb
+++ b/lib/rspec-puppet/adapters.rb
@@ -139,7 +139,8 @@ module RSpec::Puppet
         Puppet.push_context(
           {
             :environments => loader,
-            :current_environment => env
+            :current_environment => env,
+            :loaders => Puppet::Pops::Loaders.new(env),
           },
           "Setup rspec-puppet environments"
         )


### PR DESCRIPTION
This will allow the user to test classes using deferred 4.x functions, such as:

``` puppet
class deferred_functions {
  notify { 'message':
    message => Deferred(
                   'inline_epp',
                   [
                     'VAULT_VALUE=<%= unwrap($secret) %>',
                     {'secret'=> Sensitive('a thing') }
                   ]
               )
  }
}
```

Fixes #782

See https://tickets.puppetlabs.com/browse/PDK-1715 for more info.

Co-authored-by: Josh Cooper <joshcooper@users.noreply.github.com>